### PR TITLE
Prestige

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -167,6 +167,11 @@ const UserActions = {
         dom.renderPokeList();
         renderView(dom, enemy, player);
     },
+    prestigePokemon: function(pokemonIndex) {
+      player.getPokemon()[pokemonIndex].tryPrestige(player.getPokemon()[pokemonIndex].shiny());
+      dom.renderPokeList();
+      renderView(dom, enemy, player);
+    },
     moveToStorage: function(pokemonIndex) {
         // you must keep at least one active pokemon
         if (player.pokemons.length > 1) {

--- a/src/display.js
+++ b/src/display.js
@@ -162,12 +162,13 @@ const Display = {
             const listItemElement = listElement.querySelector('#listPoke' + index);
             if (listItemElement) {
                 const listItemNameElement = listItemElement.querySelector('.pokeListName');
-                let hasChanged = (listItemNameElement.innerHTML !== `${poke.pokeName()} (${poke.level()})`) || (listItemNameElement.getAttribute('status') !== this.pokeStatus(poke));
-                listItemNameElement.innerHTML = `${poke.pokeName()} (${poke.level()})`;
+                let hasChanged = (listItemNameElement.innerHTML !== `${poke.pokeName()} (${poke.level() + (poke.prestigeLevel ? ("p" + poke.prestigeLevel) : "")})`) || (listItemNameElement.getAttribute('status') !== this.pokeStatus(poke));
+                listItemNameElement.innerHTML = `${poke.pokeName()} (${poke.level() + (poke.prestigeLevel ? ("p" + poke.prestigeLevel) : "")})`;
                 listItemNameElement.setAttribute('status', this.pokeStatus(poke));
                 listItemNameElement.className = 'pokeListName ' + this.pokeStatus(poke)
                     + (poke === player.activePoke() ? ' activePoke' : '')
-                    + (poke.canEvolve() ? ' canEvolve' : '');
+                    + (poke.canEvolve() ? ' canEvolve' : '')
+                    + (poke.canPrestige() ? ' canPrestige' : '');
                 listItemElement.querySelector('img').setAttribute('src', poke.image()['front']);
                 if (!purge && hasChanged) {
                     flash(listItemElement);
@@ -177,16 +178,18 @@ const Display = {
                 const downButton = `<button onclick="userInteractions.pokemonToDown(${index})" class="pokeDownButton"><i class="fa fa-arrow-down" aria-hidden="true"></i></button>`;
                 const firstButton = `<button onclick="userInteractions.pokemonToFirst(${index})" class="pokeFirstButton">#1</button>`;
                 const evolveButton = `<button onclick="userInteractions.evolvePokemon(${index})" class="pokeEvolveButton">Evolve</button>`;
+                const prestigeButton = `<button onclick="userInteractions.prestigePokemon(${index})" class="pokePrestigeButton">Prestige</button>`;
                 const storageButton = `<button onclick="userInteractions.moveToStorage(${index})" class="toStorageButton">PC</button>`;
                 const image = '<p><a href="#" onclick="userInteractions.changePokemon(' + index + ')"><img src="' + poke.image()['front'] + '"></a></p>';
 
                 listElementsToAdd += `<li id="listPoke${index}" class="listPoke">` +
                     image +
-                    `<a href="#" onclick="userInteractions.changePokemon(${index})" class="pokeListName ${this.pokeStatus(poke)}" status="${this.pokeStatus(poke)}">${poke.pokeName()} (${poke.level()})</a><br>` +
+                    `<a href="#" onclick="userInteractions.changePokemon(${index})" class="pokeListName ${this.pokeStatus(poke)}" status="${this.pokeStatus(poke)}">${poke.pokeName()} (${poke.level() + (poke.prestigeLevel ? ("p" + poke.prestigeLevel) : "")})</a><br>` +
                     upButton +
                     downButton +
                     firstButton +
                     evolveButton +
+                    prestigeButton +
                     storageButton +
                     `</li>`
             }

--- a/src/player.js
+++ b/src/player.js
@@ -356,10 +356,11 @@ let Player = {
                 const exp = loadedPoke[1];
                 const shiny = (loadedPoke[2] === true);
                 const caughtAt = loadedPoke[3];
+                const prestigeLevel = loadedPoke[4] || 0;
                 if (pokeCount < 6) {
-                    this.pokemons.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                    this.pokemons.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
                 } else {
-                    this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                    this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
                 }
                 pokeCount++;
             }
@@ -371,7 +372,8 @@ let Player = {
                 const exp = loadedPoke[1];
                 const shiny = (loadedPoke[2] === true);
                 const caughtAt = loadedPoke[3];
-                this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                const prestigeLevel = loadedPoke[4] || 0;
+                this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
             }
         });
         if (JSON.parse(localStorage.getItem('ballsAmount'))) {
@@ -418,10 +420,11 @@ let Player = {
                 const exp = loadedPoke[1];
                 const shiny = (loadedPoke[2] === true);
                 const caughtAt = loadedPoke[3];
+                const prestigeLevel = loadedPoke[4] || 0;
                 if (pokeCount < 6) {
-                    this.pokemons.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                    this.pokemons.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
                 } else {
-                    this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                    this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
                 }
                 pokeCount++;
             });
@@ -430,7 +433,8 @@ let Player = {
                 const exp = loadedPoke[1];
                 const shiny = (loadedPoke[2] === true);
                 const caughtAt = loadedPoke[3];
-                this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt));
+                const prestigeLevel = loadedPoke[4] || 0;
+                this.storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel));
             });
             this.ballsAmount = saveData.ballsAmount; // import from old spelling mistake
             this.currencyAmount = saveData.currencyAmount;

--- a/src/poke.js
+++ b/src/poke.js
@@ -1,9 +1,10 @@
-let Poke = function(pokeModel, initialLevel, initialExp, shiny, caughtAt) {
+let Poke = function(pokeModel, initialLevel, initialExp, shiny, caughtAt, prestigeLevel = 0) {
     this.poke = cloneJsonObject(pokeModel);
     this.expTable = EXP_TABLE[this.poke.stats[0]["growth rate"]];
     this.exp = initialLevel && this.expTable[initialLevel - 1] || initialExp;
     this.isShiny = (shiny === true);
     this.caughtAt = caughtAt || Date.now();
+    this.prestigeLevel = prestigeLevel;
     this.hp = this.setHpValue(this.poke.stats[0].hp) * 3;
 };
 Poke.prototype.currentLevel = function() {
@@ -12,7 +13,7 @@ Poke.prototype.currentLevel = function() {
         .length;
 };
 Poke.prototype.statValue = function(raw) {
-    return Math.floor((((raw + 50) * this.currentLevel()) / 150))
+    return Math.floor((((raw + 50) * this.currentLevel()) / 150) * Math.pow(1.25, this.prestigeLevel))
 };
 Poke.prototype.setHpValue = function(rawHp) {
     return Math.floor(((rawHp * this.currentLevel()) / 40))
@@ -58,6 +59,15 @@ Poke.prototype.canEvolve = function() {
         }
     }
     return false;
+};
+Poke.prototype.tryPrestige = function() {
+  if (this.canPrestige()) {
+    this.exp = this.expTable[4];
+    this.prestigeLevel++;
+  }
+};
+Poke.prototype.canPrestige = function() {
+  return this.level() >= 100;
 };
 
 Poke.prototype.setHp = function(hp) { this.hp = hp; };
@@ -112,6 +122,6 @@ Poke.prototype.takeDamage = function(enemyAttack) {
 };
 Poke.prototype.baseExp = function() { return Number(this.poke.exp[0]['base exp']); };
 Poke.prototype.heal = function() { return this.setHp(this.maxHp()); };
-Poke.prototype.save = function() { return [this.poke.pokemon[0].Pokemon, this.exp, this.isShiny, this.caughtAt]; };
+Poke.prototype.save = function() { return [this.poke.pokemon[0].Pokemon, this.exp, this.isShiny, this.caughtAt, this.prestigeLevel]; };
 
 const makeRandomPoke = (level) => new Poke(randomArrayElement(POKEDEX), level);

--- a/style.css
+++ b/style.css
@@ -68,7 +68,8 @@ ul {
 .pokeDownButton,
 .pokeFirstButton,
 .toStorageButton,
-.pokeEvolveButton {
+.pokeEvolveButton,
+.pokePrestigeButton {
     display: none;
 }
 
@@ -83,7 +84,8 @@ ul {
 .manageTeamEnabled .pokeDownButton,
 .manageTeamEnabled .pokeFirstButton,
 .manageTeamEnabled .toStorageButton,
-.manageTeamEnabled .canEvolve ~ .pokeEvolveButton {
+.manageTeamEnabled .canEvolve ~ .pokeEvolveButton,
+.manageTeamEnabled .canPrestige ~ .pokePrestigeButton {
     display: inline;
     padding-left: 3px;
     padding-right: 3px;


### PR DESCRIPTION
 - Pokémon at level 100 have the ability to "prestige", resetting their level back to 5 but gaining a multiplicative 25% bonus to their base stats, excluding hp (this should probably be nerfed)
 - Pokémon with at least one prestige level will have it appended to their name in the Pokémon list

This code probably requires some cleaning up, but it should provide an example on how to implement a prestige-like feature.