### PR TITLE
Fix hp overflow when upgrading prestige level

### DIFF
--- a/src/poke.js
+++ b/src/poke.js
@@ -63,6 +63,7 @@ Poke.prototype.canEvolve = function() {
 Poke.prototype.tryPrestige = function() {
   if (this.canPrestige()) {
     this.exp = this.expTable[4];
+    this.setHp(this.maxHp());
     this.prestigeLevel++;
   }
 };


### PR DESCRIPTION
Using the prestige function would not reset their hp to their new max. This should fix that issue.