### PR TITLE
Add workflow to draft a new release

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,59 @@
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The new version number you want to release.'
+        required: true
+
+jobs:
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Build release files for Github Pages
+        run: |
+          npm ci
+          npm run build:gh-pages
+
+      # In order to make a commit, we need to initialize a user.
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "No Name Release Bot"
+          git config user.email noreply@github.com
+
+      - name: Commit release files
+        id: make-commit
+        run: |
+          git add -A
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+
+      - name: Bump version in package.json
+        run: npm version ${{ github.event.inputs.version }}
+
+      - name: Push new branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: master
+          title: Release version ${{ github.event.inputs.version }}
+          reviewers: ${{ github.actor }} # By default, we request a review from the person who triggered the workflow.
+          # Write a nice message to the user.
+          # We are claiming things here based on the `publish-new-release.yml` workflow.
+          # You should obviously adopt it to say the truth depending on your release workflow :)
+          body: |
+            Hi @${{ github.actor }}!
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've rebuilt the Github Pages files and bumped the versions in the manifest files to ${{ github.event.inputs.version }}.
+            Merging this PR will update the live site.


### PR DESCRIPTION
Automated releasing, so you don't even need to be at your computer to update the website :)
Instructions for how to use this are on discord in #dev-guides, I'll paste them here too though

I don't think you will have any way of testing this before merging, but it can't possibly break anything by doing so. You can also check the open pull request on my fork for an example of how it will look: Aegyo/unclebanks.github.io#7


1. Log into github and go to the Actions tab (on your repo, not the one in this screenshot)
![Step 1](https://cdn.discordapp.com/attachments/805360683528880139/816466619349205012/unknown.png)

2. There should be a "Draft new release" button you can click
![Step 2](https://cdn.discordapp.com/attachments/805360683528880139/816466822534135818/unknown.png)
3. Click "Run workflow" dropdown on the right, pick the branch which is ready to be built for the live site, enter a new version number, and hit the green button
![Step 3](https://cdn.discordapp.com/attachments/805360683528880139/816467278165966868/unknown.png)
4. Cross your fingers and hope a PR shows up from a github bot.
5.
- If you got a PR, check it seems ok and merge it into master - this should update the website
- If you didn't get a PR, you can come back to the Actions tab (refresh), and click the latest entry for more details. It might just be taking a while, or may have failed for some reason. If it failed, fix whatever it complained about and try again.