### PR TITLE
chore(workflow): Add workflow to update develop when master changes

### DIFF
--- a/.github/workflows/update-develop.yml
+++ b/.github/workflows/update-develop.yml
@@ -1,0 +1,58 @@
+name: "Update develop with master"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Update develop with master
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from branch name (for hotfix branches)
+        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      # Not sure we want this yet
+      #
+      # - name: Create Release
+      #   uses: thomaseizinger/create-release@1.0.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+      #     tag_name: ${{ env.RELEASE_VERSION }}
+      #     name: ${{ env.RELEASE_VERSION }}
+      #     draft: false
+      #     prerelease: false
+
+      - name: Merge master into dev branch
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: master
+          base: develop
+          title: Merge master into dev branch
+          body: |
+            This PR merges the master branch back into dev.
+            This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.
+
+      # if needed, you can checkout the latest master here, build artifacts and publish / deploy them somewhere
+      # the create-release action has an output `upload_url` output that you can use to upload assets


### PR DESCRIPTION
This makes sure that the version number updates when releasing, and docs folder, is all up to date on develop without any manual work.

It will also pick up an hotfixes or other merges into master, as long as they are made through a PR. If master is only updated through PRs from now on, develop should be kept updated.

Example PR the bot will make after a merge into master: Aegyo/unclebanks.github.io#10

Both of these workflows we have were made by making small modifications to these: https://github.com/thomaseizinger/github-action-gitflow-release-workflow