### PR TITLE
chore(migrate/vue): Move Settings modal into a Vue component

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,9 @@
 import { createApp } from 'vue';
+
+// Modals
+import SettingsModal from './components/modals/SettingsModal.vue';
+
+// Main UI
 import App from './components/App.vue';
 import PokemonList from './components/PokemonList.vue';
 import RoutesBox from './components/RoutesBox.vue';
@@ -9,8 +14,9 @@ import PlayerBox from './components/PlayerBox.vue';
 import Console from './components/Console.vue';
 import NavBox from './components/NavBox.vue';
 
-export default () => {
+export default (userInteractions) => {
     const app = createApp(App);
+    const settingsModal = createApp(SettingsModal);
 
     app.component('PokemonList', PokemonList);
     app.component('RoutesBox', RoutesBox);
@@ -21,5 +27,8 @@ export default () => {
     app.component('Console', Console);
     app.component('NavBox', NavBox);
 
-    return app.mount('#app');
+    return {
+        app: app.mount('#app'),
+        settings: settingsModal.mount('#settingsContainer'),
+    };
 };

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ import PlayerBox from './components/PlayerBox.vue';
 import Console from './components/Console.vue';
 import NavBox from './components/NavBox.vue';
 
-export default (userInteractions) => {
+export default () => {
     const app = createApp(App);
     const settingsModal = createApp(SettingsModal);
 

--- a/src/components/NavBox.vue
+++ b/src/components/NavBox.vue
@@ -20,7 +20,7 @@
     </button><br>
     <button
       class="button-old modal-button"
-      data-target="settingsContainer"
+      data-target="settingsModal"
     >
       Settings
     </button><br>

--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -1,0 +1,17 @@
+<template>
+  <button
+    class="button"
+    :class="classes"
+  >
+    {{ text }}
+  </button>
+</template>
+
+<script>
+export default {
+    props: {
+        classes: { type: String, default: '' },
+        text: { type: String, default: '' },
+    },
+};
+</script>

--- a/src/components/common/CardModal.vue
+++ b/src/components/common/CardModal.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    :id="modalName"
+    class="modal"
+  >
+    <div class="modal-background" />
+    <div
+      :id="dialogName"
+      class="modal-card"
+    >
+      <header class="modal-card-head">
+        <p class="modal-card-title">
+          {{ title }}
+        </p>
+        <button
+          class="delete"
+          aria-label="close"
+        />
+      </header>
+
+      <section class="modal-card-body">
+        <slot name="body" />
+      </section>
+
+      <footer class="modal-card-foot">
+        <button class="button">
+          Close
+        </button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+    props: {
+        name: { type: String, default: '', required: true },
+        title: { type: String, default: '', required: true },
+    },
+
+    computed: {
+        modalName() { return `${this.name}Modal`; },
+        dialogName() { return `${this.name}Dialog`; },
+    },
+};
+</script>

--- a/src/components/modals/SettingsModal.vue
+++ b/src/components/modals/SettingsModal.vue
@@ -14,13 +14,13 @@
             id="spriteChoiceBack"
             type="radio"
             name="spriteChoice"
-            onchange="userInteractions.changeSpriteChoice()"
+            @change="ui.changeSpriteChoice()"
           ><label for="spriteChoiceBack">Back</label>
           <input
             id="spriteChoiceFront"
             type="radio"
             name="spriteChoice"
-            onchange="userInteractions.changeSpriteChoice()"
+            @change="ui.changeSpriteChoice()"
           ><label for="spriteChoiceFront">Front</label>
         </span>
       </p>
@@ -32,35 +32,32 @@
           checked="true"
         ><span>Enable console</span>
       </p>
-      <button
-        class="button is-warning"
-        onclick="userInteractions.clearConsole()"
-      >
-        Clear Console
-      </button>
+      <Button
+        text="Clear Console"
+        classes="is-warning"
+        @click="ui.clearConsole()"
+      />
       <h4>Import and Export Save</h4>
       <div class="buttons">
-        <button
-          class="button is-primary"
-          onclick="userInteractions.forceSave()"
-        >
-          Force Save
-        </button> <span
+        <Button
+          text="Force Save"
+          classes="is-primary"
+          @click="ui.forceSave()"
+        />
+        <span
           id="forceSave"
           style="color:red"
         >Saved!</span>
-        <button
-          class="button is-primary"
-          onclick="userInteractions.exportSaveDialog()"
-        >
-          Export
-        </button>
-        <button
-          class="button is-primary"
-          onclick="userInteractions.importSaveDialog()"
-        >
-          Import
-        </button>
+        <Button
+          text="Export"
+          classes="is-primary"
+          @click="ui.exportSaveDialog()"
+        />
+        <Button
+          text="Import"
+          classes="is-primary"
+          @click="ui.importSaveDialog()"
+        />
       </div>
       <h4>Clear Game Data</h4>
       <p style="color:red;font-weight:bold">
@@ -92,10 +89,18 @@ export default {
         Button,
     },
 
+    // Defines what data this component wants
     data() {
         return {
             ui: {
+                // Giving a default functions that do nothing
+                // They will be replaced later when ui is passed to us
                 clearGameData() {},
+                importSaveDialog() {},
+                exportSaveDialog() {},
+                forceSave() {},
+                clearConsole() {},
+                changeSpriteChoice() {},
             },
         };
     },

--- a/src/components/modals/SettingsModal.vue
+++ b/src/components/modals/SettingsModal.vue
@@ -1,0 +1,103 @@
+<template>
+  <CardModal
+    name="settings"
+    title="Settings"
+  >
+    <template
+      #body
+    >
+      <h4>Visual Settings</h4>
+      <p>Choose which sprite You want to display for your pokemon:</p>
+      <p>
+        <span class="spriteChoice">
+          <input
+            id="spriteChoiceBack"
+            type="radio"
+            name="spriteChoice"
+            onchange="userInteractions.changeSpriteChoice()"
+          ><label for="spriteChoiceBack">Back</label>
+          <input
+            id="spriteChoiceFront"
+            type="radio"
+            name="spriteChoice"
+            onchange="userInteractions.changeSpriteChoice()"
+          ><label for="spriteChoiceFront">Front</label>
+        </span>
+      </p>
+      <h4>Console Settings</h4>
+      <p>
+        <input
+          id="enableConsole"
+          type="checkbox"
+          checked="true"
+        ><span>Enable console</span>
+      </p>
+      <button
+        class="button is-warning"
+        onclick="userInteractions.clearConsole()"
+      >
+        Clear Console
+      </button>
+      <h4>Import and Export Save</h4>
+      <div class="buttons">
+        <button
+          class="button is-primary"
+          onclick="userInteractions.forceSave()"
+        >
+          Force Save
+        </button> <span
+          id="forceSave"
+          style="color:red"
+        >Saved!</span>
+        <button
+          class="button is-primary"
+          onclick="userInteractions.exportSaveDialog()"
+        >
+          Export
+        </button>
+        <button
+          class="button is-primary"
+          onclick="userInteractions.importSaveDialog()"
+        >
+          Import
+        </button>
+      </div>
+      <h4>Clear Game Data</h4>
+      <p style="color:red;font-weight:bold">
+        Warning! This cannot be undone.
+      </p>
+      <p>
+        <input
+          id="confirmClearData"
+          type="checkbox"
+        >
+        <Button
+          text="Clear game data"
+          classes="is-danger"
+          @click="ui.clearGameData()"
+        />
+      </p>
+    </template>
+  </CardModal>
+</template>
+
+<script>
+import CardModal from '../common/CardModal.vue';
+import Button from '../common/Button.vue';
+
+export default {
+
+    components: {
+        CardModal,
+        Button,
+    },
+
+    data() {
+        return {
+            ui: {
+                clearGameData() {},
+            },
+        };
+    },
+};
+</script>

--- a/src/components/modals/SettingsModal.vue
+++ b/src/components/modals/SettingsModal.vue
@@ -3,11 +3,11 @@
     name="settings"
     title="Settings"
   >
-    <template
-      #body
-    >
+    <template #body>
       <h4>Visual Settings</h4>
+
       <p>Choose which sprite You want to display for your pokemon:</p>
+
       <p>
         <span class="spriteChoice">
           <input
@@ -16,6 +16,7 @@
             name="spriteChoice"
             @change="ui.changeSpriteChoice()"
           ><label for="spriteChoiceBack">Back</label>
+
           <input
             id="spriteChoiceFront"
             type="radio"
@@ -24,7 +25,9 @@
           ><label for="spriteChoiceFront">Front</label>
         </span>
       </p>
+
       <h4>Console Settings</h4>
+
       <p>
         <input
           id="enableConsole"
@@ -32,42 +35,52 @@
           checked="true"
         ><span>Enable console</span>
       </p>
+
       <Button
         text="Clear Console"
         classes="is-warning"
         @click="ui.clearConsole()"
       />
+
       <h4>Import and Export Save</h4>
+
       <div class="buttons">
         <Button
           text="Force Save"
           classes="is-primary"
           @click="ui.forceSave()"
         />
+
         <span
           id="forceSave"
           style="color:red"
         >Saved!</span>
+
         <Button
           text="Export"
           classes="is-primary"
           @click="ui.exportSaveDialog()"
         />
+
         <Button
           text="Import"
           classes="is-primary"
           @click="ui.importSaveDialog()"
         />
       </div>
+
       <h4>Clear Game Data</h4>
+
       <p style="color:red;font-weight:bold">
         Warning! This cannot be undone.
       </p>
+
       <p>
         <input
           id="confirmClearData"
           type="checkbox"
         >
+
         <Button
           text="Clear game data"
           classes="is-danger"

--- a/src/index.html
+++ b/src/index.html
@@ -63,41 +63,7 @@
         </div>
     </div>
 
-    <div id="settingsContainer" class="modal">
-        <div class="modal-background"></div>
-        <div id="settingsDialog" class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">Settings</p>
-                <button class="delete" aria-label="close"></button>
-            </header>
-            <section class="modal-card-body">
-                <h4>Visual Settings</h4>
-                <p>Choose which sprite You want to display for your pokemon:</p>
-                <p>
-                <span class="spriteChoice">
-                  <input type="radio" id="spriteChoiceBack" name="spriteChoice" onchange="userInteractions.changeSpriteChoice()" /><label for="spriteChoiceBack">Back</label>
-                  <input type="radio" id="spriteChoiceFront" name="spriteChoice" onchange="userInteractions.changeSpriteChoice()" /><label for="spriteChoiceFront">Front</label>
-                </span>
-                </p>
-                <h4>Console Settings</h4>
-                <p><input type="checkbox" checked="true" id="enableConsole"><span>Enable console</span></p>
-                <button class="button is-warning" onclick="userInteractions.clearConsole()">Clear Console</button>
-                <h4>Import and Export Save</h4>
-                <div class="buttons">
-                    <button class="button is-primary" onclick="userInteractions.forceSave()">Force Save</button> <span id="forceSave" style="color:red">Saved!</span>
-                    <button class="button is-primary" onclick="userInteractions.exportSaveDialog()">Export</button>
-                    <button class="button is-primary" onclick="userInteractions.importSaveDialog()">Import</button>
-                </div>
-                <h4>Clear Game Data</h4>
-                <p style="color:red;font-weight:bold">Warning! This cannot be undone.</p>
-                <p><input type="checkbox" id="confirmClearData">
-                    <button class="button is-danger" onclick="userInteractions.clearGameData()">Clear game data</button></p>
-            </section>
-            <footer class="modal-card-foot">
-                <button class="button">Close</button>
-            </footer>
-        </div>
-    </div>
+    <div id="settingsContainer"></div>
 
     <div id="townContainer" class="modalContainer" style="display: none">
         <div id="townDialog" class="modalDialog">

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,6 @@ if (localStorage.getItem('totalPokes') !== null) {
 
 if (player.settings.spriteChoice === 'front') {
     document.getElementById('spriteChoiceFront').checked = true;
-    document.getElementById('player').className += ' frontSprite';
 } else {
     document.getElementById('spriteChoiceBack').checked = true;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import initApp from './app';
 // import just the bits of fontawesome we want
 import(/* webpackChunkName: "fontawesome" */ './modules/fontawesome');
 
-initApp();
+const models = initApp();
 
 document.addEventListener('DOMContentLoaded', () => {
     setupModals();
@@ -31,6 +31,9 @@ const town = Town(player, Poke);
 const story = Story(player, enemy, combatLoop, Poke);
 const userInteractions = UserActions(player, combatLoop, enemy, town, story);
 const dom = Display(player, combatLoop, userInteractions);
+
+// Provide data to Vue components
+models.settings.ui = userInteractions;
 
 combatLoop.attachUI(userInteractions);
 enemy.attachCL(combatLoop);

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -256,10 +256,8 @@ export default (player, combatLoop, enemy, town, story) => {
         changeSpriteChoice: function () {
             if (document.getElementById('spriteChoiceFront').checked) {
                 player.settings.spriteChoice = 'front';
-                document.getElementById('player').className = 'container poke frontSprite';
             } else {
                 player.settings.spriteChoice = 'back';
-                document.getElementById('player').className = 'container poke';
             }
             player.savePokes();
             renderView(dom, enemy, player);


### PR DESCRIPTION
Another Vue component, this time with new things!
 - Importing a component you need directly in the .vue, instead of setting it up in app.js
 - Passing properties to components in a template (see: Button, CardModal)
 - Providing external state - Settings modal now doesn't need userInteractions to be a global
 - Event handling with Vue - `@eventName="handler()"` (see Buttons, and the radio inputs)
 - Providing element content with `<slot name="something">` place holders (see `<template #body>` inside the CardModal for Settings. "body" is the slot name)
 - Using a component property for content with `{{ mustaches }}` (see CardModal `title`)
 - Multiple Vue `createApp` calls - we can manage many separate models if we want to. I am not sure what the best practice is here, but nice to know this is an option.