### PR TITLE
chore: Expose more variables as globals when in development environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,11 +45,29 @@ enemy.attachCL(combatLoop);
     town,
 ].forEach((obj) => obj.attachDOM(dom));
 
-const globals = {
-    userInteractions,
-    story,
-    town,
-};
+let globals;
+if (process.env.NODE_ENV === 'development') {
+    // Expose all of the things in development, for easier debugging
+    globals = {
+        lastSave,
+        player,
+        Poke,
+        enemy,
+        combatLoop,
+        town,
+        story,
+        userInteractions,
+        dom,
+        models,
+    };
+} else {
+    // Otherwise, just the things we need to make the game run
+    globals = {
+        userInteractions,
+        story,
+        town,
+    };
+}
 
 // expose globals for use on inline event handlers in html
 Object.assign(window, globals);

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -1,4 +1,5 @@
 const { merge } = require('webpack-merge');
+const { mode } = require('webpack-nano/argv');
 const path = require('path');
 const parts = require('./parts');
 
@@ -27,6 +28,8 @@ const getCommon = ({ outputPath, sourcePath, entries }) => (merge(
 
     // Remove old files before generating more
     parts.cleanBuild(outputPath),
+
+    parts.setFreeVariable('NODE_ENV', mode),
 
     // Where to start looking for things to bundle
     { entry: ['./src'] },

--- a/webpack/parts.js
+++ b/webpack/parts.js
@@ -6,6 +6,7 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 const TerserPlugin = require('terser-webpack-plugin');
 const CompressionWebpackPlugin = require('compression-webpack-plugin');
+const { webpack, DefinePlugin } = require('webpack');
 
 exports.loadSCSS = () => ({
     module: {
@@ -94,5 +95,13 @@ exports.minifyJavaScript = () => ({
 exports.compressFiles = (options) => ({
     plugins: [
         new CompressionWebpackPlugin(options),
+    ],
+});
+
+exports.setFreeVariable = (key, value) => ({
+    plugins: [
+        new DefinePlugin({
+            [key]: JSON.stringify(value),
+        }),
     ],
 });


### PR DESCRIPTION
This adds a check to see if the game was built in 'development' mode, and if so will expose much more in the global scope.

The extra bit in the webpack config is to make the build mode variable available to game code, in a way that allows javascript minifiers to cut out the section we don't need. When built in 'production' mode, the final code doesn't even have that `if (process.env.NODE_ENV === 'development') {` block, it is completely cut out because the minifier is smart enough to figure out this bit will never be true at runtime.

Through `npm start`:
![console in dev mode](https://imgur.com/E4AvjaD.png)

Through `npm run build` and opening the `/dist/index.html` file:
![console in prod mode](https://imgur.com/wqtyZqU.png)