### PR TITLE
fix: Ball Icons

### DIFF
--- a/src/components/Inventory.vue
+++ b/src/components/Inventory.vue
@@ -17,10 +17,8 @@
       checked="true"
       onclick="userInteractions.changeSelectedBall('pokeball')"
     ><label for="pokeball"><span title="Pokeball"><img
-      class="pokeballImg"
+      class="pokeballImg ballIcon"
       src="assets/images/pokeballs/poke.png"
-      height="14px"
-      width="14px"
     ></span>Pokeballs: <span class="ball-amount pokeball">10</span></label><br>
     <input
       id="greatball"
@@ -29,10 +27,8 @@
       value="greatball"
       onclick="userInteractions.changeSelectedBall('greatball')"
     ><label for="greatball"><span title="Greatball"><img
-      class="greatballImg"
+      class="greatballImg ballIcon"
       src="assets/images/pokeballs/great.png"
-      height="14px"
-      width="14px"
     ></span>Greatballs: <span class="ball-amount greatball">0</span></label><br>
     <input
       id="ultraball"
@@ -41,10 +37,8 @@
       value="ultraball"
       onclick="userInteractions.changeSelectedBall('ultraball')"
     ><label for="ultraball"><span title="Ultraball"><img
-      class="UltraballImg"
+      class="UltraballImg ballIcon"
       src="assets/images/pokeballs/ultra.png"
-      height="14px"
-      width="14px"
     ></span>Ultraballs: <span class="ball-amount ultraball">0</span></label><br>
     <input
       id="masterball"
@@ -53,38 +47,30 @@
       value="ultraball"
       onclick="userInteractions.changeSelectedBall('masterball')"
     ><label for="masterball"><span title="Masterball"><img
-      class="MasterballImg"
+      class="MasterballImg ballIcon"
       src="assets/images/pokeballs/master.png"
-      height="14px"
-      width="14px"
     ></span>Masterballs: <span class="ball-amount masterball">0</span></label><br>
     <span>Currency:</span><br>
     <span
       id="pokeC"
       title="PokeCoins"
     ><img
-      class="pokecoins"
+      class="pokecoins coinIcon"
       src="assets/images/currency/PokeCoin.png"
-      height="16"
-      width="16"
     ></span> PokeCoins: <span id="pokeCoins">0</span><br>
     <span
       id="catchC"
       title="CatchCoins"
     ><img
-      class="catchcoins"
+      class="catchcoins coinIcon"
       src="assets/images/currency/CatchCoin.png"
-      height="16"
-      width="16"
     ></span> CatchCoins: <span id="catchCoins">0</span><br>
     <span
       id="battleC"
       title="BattleCoins"
     ><img
-      class="battlecoins"
+      class="battlecoins coinIcon"
       src="assets/images/currency/BattleCoin.png"
-      height="16"
-      width="16"
     ></span> BattleCoins: <span id="battleCoins">0</span><br>
   </div>
 </template>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -445,3 +445,13 @@ progress.expBar {
 ul#shopItems li {
     margin-top: 2px;
 }
+
+.ballIcon {
+    height: auto;
+    width: 14px;
+}
+
+.coinIcon {
+    height: auto;
+    width: 16px;
+}


### PR DESCRIPTION
Makes pokeball, greatball, and ultraball visible again.
Also moves the coin icon height/widths into a css class to prevent whatever weirdness is affecting the balls also happening to the coins.