### PR TITLE
Update evo code to check player.unlocked for stones

### DIFF
--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -44,7 +44,7 @@ export default (player) => {
                     player.addPokedex(oldPokemon, (shiny ? POKEDEXFLAGS.ownedShiny : POKEDEXFLAGS.ownedNormal));
                 }
             }
-            if (player.evoStones[stoneType]) {
+            if (player.unlocked[stoneType]) {
                 this.poke = cloneJsonObject(pokeByName(evolution));
                 player.addPokedex(evolution, (shiny ? POKEDEXFLAGS.ownShiny : POKEDEXFLAGS.ownNormal));
                 if (!player.hasPokemon(oldPokemon, shiny)) {
@@ -63,7 +63,7 @@ export default (player) => {
                     return true;
                 }
             }
-            if (player.evoStones[stoneType]) {
+            if (player.unlocked[stoneType]) {
                 if (!player.hasPokemon(EVOLUTIONS[this.poke.pokemon[0].Pokemon].to, 0)) {
                     return true;
                 }


### PR DESCRIPTION
Buying the evo stones only sets player.unlocked, but the code was expecting a flag on player.evoStones, making anyone who bought the evo stones recently unable to use them.