### PR TITLE
Fix catching shinies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
         'quote-props': 'off',
         'func-names': 'off',
         'object-shorthand': 'off',
-        'no-bitwise': 'off',
         'no-plusplus': 'off',
         'eqeqeq': 'off',
         'max-len': 'off',

--- a/src/modules/combat.js
+++ b/src/modules/combat.js
@@ -189,7 +189,12 @@ export default (player, enemy) => {
             dom.renderPokeList(false);
         },
         attemptCatch: function () {
-            if (Combat.catchEnabled == 'all' && !Combat.trainer || (Combat.catchEnabled == 'new' && !player.hasPokemon(enemy.activePoke().pokeName(), 0)) && !Combat.trainer) {
+            if (
+                !Combat.trainer && (
+                    (Combat.catchEnabled == 'all')
+                    || (Combat.catchEnabled == 'new' && !player.hasPokemonLike(enemy.activePoke()))
+                )
+            ) {
                 const selectedBall = (enemy.activePoke().shiny() ? player.bestAvailableBall() : player.selectedBall);
                 if (player.consumeBall(selectedBall)) {
                 // add throw to statistics
@@ -203,8 +208,8 @@ export default (player, enemy) => {
                         player.statistics.successfulThrows++;
                         player.statistics[`${selectedBall}SuccessfulThrows`]++;
                         player.addCatchCoins(gainCatchCoins);
-                        if (!player.hasPokemon(enemy.activePoke().pokeName(), 0)) {
-                            player.addPoke(enemy.activePoke(), 0);
+                        if (!player.hasPokemonLike(enemy.activePoke())) {
+                            player.addPoke(enemy.activePoke());
                             dom.renderPokeList();
                         }
                         player.addPokedex(enemy.activePoke().pokeName(), (enemy.activePoke().shiny() ? POKEDEXFLAGS.ownShiny : POKEDEXFLAGS.ownNormal));

--- a/src/modules/enemy.js
+++ b/src/modules/enemy.js
@@ -9,7 +9,7 @@ export default (starter, player, Poke) => {
         poke,
         level,
         false,
-        Math.random() < (1 / (1 << 5 << 8)),
+        Math.random() < (1 / (2 ** 13)),
     );
 
     const trainerPoke = (pokemonList) => {
@@ -23,15 +23,15 @@ export default (starter, player, Poke) => {
         const regionData = ROUTES[regionId];
         const routeData = regionData[routeId];
         let pokemonList = [];
-            pokemonList = routeData.pokes;
+        pokemonList = routeData.pokes;
         if (regionData._global) {
-            if (regionData._global.pokes && Math.random() < (1 / (1 << 8))) {
+            if (regionData._global.pokes && Math.random() < (1 / (2 ** 8))) {
                 pokemonList = mergeArray(pokemonList, regionData._global.pokes);
             }
-            if (regionData._global.rarePokes && Math.random() < (1 / (1 << 14))) {
+            if (regionData._global.rarePokes && Math.random() < (1 / (2 ** 14))) {
                 pokemonList = mergeArray(pokemonList, regionData._global.rarePokes);
             }
-            if (regionData._global.superRare && Math.random() < (1 / (1 << 16))) {
+            if (regionData._global.superRare && Math.random() < (1 / (2 ** 16))) {
                 pokemonList = mergeArray(pokemonList, regionData._global.superRare);
             }
         }

--- a/src/modules/player.js
+++ b/src/modules/player.js
@@ -144,6 +144,7 @@ export default (lastSave, appModel) => {
             for (let i = 0; i < len; i++) {
                 chk += (s.charCodeAt(i) * (i + 1));
             }
+            // eslint-disable-next-line no-bitwise
             return (chk & 0xffffffff).toString(16);
         },
         addPoke: function (poke) {

--- a/src/modules/player.js
+++ b/src/modules/player.js
@@ -147,6 +147,13 @@ export default (lastSave, appModel) => {
             return (chk & 0xffffffff).toString(16);
         },
         addPoke: function (poke) {
+            const existing = this.getPokemonByName(poke.pokeName());
+            if (existing) {
+                // if we already have something like this, just update shiny
+                existing.isShiny = existing.shiny() || poke.shiny();
+                return;
+            }
+
             if (this.pokemons.length < 6) {
                 this.pokemons.push(poke);
             } else {
@@ -236,9 +243,18 @@ export default (lastSave, appModel) => {
             }
             return this.canHeal();
         },
+        hasPokemonLike(pokemon) {
+            return this.hasPokemon(pokemon.pokeName(), pokemon.shiny());
+        },
+        // Return true if we have this pokemon in the same shininess or better
         hasPokemon: function (pokemonName, shiny) {
-            const allPokes = mergeArray(this.pokemons, this.storage);
-            return typeof allPokes.find(function (obj) { return (this[0] == obj.pokeName() && this[1] == obj.shiny()); }, [pokemonName, shiny]) !== 'undefined';
+            // match if the name matches and we don't care about shiny, or the pokemon is shiny
+            const match = (p) => p.pokeName() === pokemonName && (!shiny || p.isShiny);
+            // findIndex will return > -1 if there is a match
+            return [...this.pokemons, ...this.storage].findIndex(match) > -1;
+        },
+        getPokemonByName: function (pokemonName) {
+            return [...this.pokemons, ...this.storage].find((p) => p.pokeName() === pokemonName);
         },
         deletePoke: function (index, from = 'roster') {
             if (from == 'roster') {

--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -20,7 +20,7 @@ export default (player) => {
             .length;
     };
     Poke.prototype.statValue = function (statName) {
-        let raw = this.poke.stats[0][statName];
+        const raw = this.poke.stats[0][statName];
         let calculated = ((raw + 50) * this.currentLevel()) / 150;
         if (statName !== 'speed') {
             calculated *= Math.pow(1.25, this.prestigeLevel);

--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -59,12 +59,12 @@ export default (player) => {
             const levelToEvolve = Number(EVOLUTIONS[this.poke.pokemon[0].Pokemon].level);
             const stoneType = EVOLUTIONS[this.poke.pokemon[0].Pokemon].stone;
             if (this.currentLevel() >= levelToEvolve) {
-                if (!player.hasPokemon(EVOLUTIONS[this.poke.pokemon[0].Pokemon].to, 0)) {
+                if (!player.hasPokemon(EVOLUTIONS[this.poke.pokemon[0].Pokemon].to, false)) {
                     return true;
                 }
             }
             if (player.unlocked[stoneType]) {
-                if (!player.hasPokemon(EVOLUTIONS[this.poke.pokemon[0].Pokemon].to, 0)) {
+                if (!player.hasPokemon(EVOLUTIONS[this.poke.pokemon[0].Pokemon].to, false)) {
                     return true;
                 }
             }

--- a/src/modules/town.js
+++ b/src/modules/town.js
@@ -197,7 +197,7 @@ export default (player, Poke) => {
             let pokecoinShopHTML = '';
             for (let i = 0; i < this.pokecoinShopItems.length; i++) {
                 let canBuy = true;
-                let own = false;
+                const own = false;
                 if (player.currencyAmount.pokecoins < this.pokecoinShopItems[i].pokecoins) canBuy = false;
                 const disableButton = (!canBuy || own) ? ' disabled="true"' : '';
                 const buttonText = (own) ? 'Own' : 'Buy';
@@ -210,7 +210,7 @@ export default (player, Poke) => {
             let pokecoinShopHTML = '';
             for (let i = 0; i < this.johtoPokecoinShopItems.length; i++) {
                 let canBuy = true;
-                let own = false;
+                const own = false;
                 if (player.currencyAmount.pokecoins < this.johtoPokecoinShopItems[i].pokecoins) canBuy = false;
                 const disableButton = (!canBuy || own) ? ' disabled="true"' : '';
                 const buttonText = (own) ? 'Own' : 'Buy';
@@ -223,7 +223,7 @@ export default (player, Poke) => {
             let pokecoinShopHTML = '';
             for (let i = 0; i < this.hoennPokecoinShopItems.length; i++) {
                 let canBuy = true;
-                let own = false;
+                const own = false;
                 if (player.currencyAmount.pokecoins < this.hoennPokecoinShopItems[i].pokecoins) canBuy = false;
                 const disableButton = (!canBuy || own) ? ' disabled="true"' : '';
                 const buttonText = (own) ? 'Own' : 'Buy';


### PR DESCRIPTION
Should allow you to catch shinies even when you already have the pokemon. It will update your existing pokemon to be shiny in that case.

Evolving shiny pokemon over an existing evolution is not included in this PR. That seemed a little more complicated and I didn't want to delay this fix.

Also switches some numbers from the bitwise shift operator into powers of two, for easier understanding, and a couple of other things eslint was complaining about.

Tested catching shinies by temporarily increasing the chance - alter the `Math.random() < (1 / (2 ** 13)),` number on line 12 of `enemy.js` if you want to do the same.