### PR TITLE
chore: Add workflow for checking build on PR

### DIFF
--- a/.github/workflows/attempt-build.yml
+++ b/.github/workflows/attempt-build.yml
@@ -1,0 +1,10 @@
+name: "Attempt Build"
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm ci
+    - run: npm run build


### PR DESCRIPTION
Simpler than I expected

Example of a PR with a failed build: Aegyo/unclebanks.github.io#13