### PR TITLE
chore: Integrate eslint with webpack and typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,13 @@ module.exports = {
     },
     extends: [
         'plugin:vue/vue3-recommended',
+        'plugin:@typescript-eslint/recommended',
         'airbnb-base',
     ],
+    parser: 'vue-eslint-parser',
     parserOptions: {
-        ecmaVersion: 12,
+        parser: '@typescript-eslint/parser',
+        ecmaVersion: 'esnext',
         sourceType: 'module',
     },
     plugins: [
@@ -39,5 +42,7 @@ module.exports = {
         'camelcase': 'off',
         'no-restricted-properties': 'off',
         'import/no-extraneous-dependencies': 'off',
+        '@typescript-eslint/no-empty-function': ['off'],
+        '@typescript-eslint/no-var-requires': ['off'],
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4531,6 +4531,27 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "eslint-webpack-plugin": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.2.tgz",
+      "integrity": "sha512-ndD9chZ/kaGnjjx7taRg7c6FK/YKb29SSYzaLtPBIYLYJQmZtuKqtQbAvTS2ymiMQT6X0VW9vZIHK0KLstv93Q==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.6",
+        "arrify": "^2.0.1",
+        "jest-worker": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        }
+      }
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1812,6 +1812,140 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz",
+      "integrity": "sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.18.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.15",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.18.0.tgz",
+      "integrity": "sha512-92h723Kblt9JcT2RRY3QS2xefFKar4ZQFVs3GityOKWQYgtajxt/tuXIzL7sVCUlM1hgreiV5gkGYyBpdOwO6A==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.18.0.tgz",
+      "integrity": "sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz",
+      "integrity": "sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz",
+      "integrity": "sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-glob": "^4.0.1",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz",
+      "integrity": "sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.18.0",
+        "eslint-visitor-keys": "^2.0.0"
+      }
+    },
     "@vue/compiler-core": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.7.tgz",
@@ -11434,6 +11568,15 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-vue": "^7.7.0",
+    "eslint-webpack-plugin": "^2.5.2",
     "favicons": "^6.2.1",
     "favicons-webpack-plugin": "^5.0.2",
     "fork-ts-checker-webpack-plugin": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "wp --mode production",
     "build:gh-pages": "npm run build -- --folder docs",
-    "start": "wp --mode development"
+    "start": "wp --mode development",
+    "lint": "npx eslint --ext .js,.ts,.vue ./src",
+    "lint:fix": "npm run lint -- --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.2",
     "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
+    "@typescript-eslint/eslint-plugin": "^4.18.0",
+    "@typescript-eslint/parser": "^4.18.0",
     "@vue/compiler-sfc": "^3.0.7",
     "autoprefixer": "^10.2.5",
     "babel-loader": "^8.2.2",

--- a/src/components/modals/VitaminModal.vue
+++ b/src/components/modals/VitaminModal.vue
@@ -6,7 +6,7 @@
     <template #body>
       <div class="section">
         <h3 class="subtitle">
-          <span id="vitaminName">Vitamin</span> - 
+          <span id="vitaminName">Vitamin</span> -
           <span id="vitaminCount">?</span>
         </h3>
       </div>

--- a/src/declarations/shims-vue.d.ts
+++ b/src/declarations/shims-vue.d.ts
@@ -1,5 +1,6 @@
 declare module '*.vue' {
-    import { defineComponent } from "vue";
+    import { defineComponent } from 'vue';
+
     const Component: ReturnType<typeof defineComponent>;
     export default Component;
   }

--- a/src/declarations/shims-vuex.d.ts
+++ b/src/declarations/shims-vuex.d.ts
@@ -1,16 +1,16 @@
-
-import { Store } from 'vuex'
-import store from '../store'
+/* eslint-disable import/prefer-default-export */
+import { Store } from 'vuex';
+import store from '../store';
 
 type State = typeof store.state;
 
 declare module '@vue/runtime-core' {
-	interface ComponentCustomProperties {
-		$store: Store<State>
-	}
+    interface ComponentCustomProperties {
+        $store: Store<State>
+    }
 }
 
 // Vuex@4.0.0-beta.1 is missing the typing for `useStore`. See https://github.com/vuejs/vuex/issues/1736
 declare module 'vuex' {
-	export function useStore(key?: string): Store<State>
+    export function useStore(key?: string): Store<State>
 }

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -381,13 +381,13 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
                 document.getElementById('badgeList').innerHTML = badgesHTML;
             }
             let inventoryHTML = '';
-            let vitamins = Object.keys(VITAMINS);
+            const vitamins = Object.keys(VITAMINS);
             for (let i = 0; i < vitamins.length; i++) {
-              let vitamin = vitamins[i];
-              let vitaminName = VITAMINS[vitamin].display;
-              let count = player.vitamins[vitamin];
-              let image = `assets/images/vitamins/${vitamin}.png`;
-              inventoryHTML += `<li class="vitaminItem"><div class="inventoryVitaminAlignmentHelper"></div><img src="${image}"></img><span class="itemName">${vitaminName}</span><button class="button" onclick="userInteractions.openVitaminModal('${vitamin}')">Use (${count} available)</button></li>`;
+                const vitamin = vitamins[i];
+                const vitaminName = VITAMINS[vitamin].display;
+                const count = player.vitamins[vitamin];
+                const image = `assets/images/vitamins/${vitamin}.png`;
+                inventoryHTML += `<li class="vitaminItem"><div class="inventoryVitaminAlignmentHelper"></div><img src="${image}"></img><span class="itemName">${vitaminName}</span><button class="button" onclick="userInteractions.openVitaminModal('${vitamin}')">Use (${count} available)</button></li>`;
             }
             document.getElementById('inventoryList').innerHTML = inventoryHTML;
             openModal(document.getElementById('inventoryModal'));
@@ -440,36 +440,36 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
             if (!VITAMINS[vitamin]) {
                 return alert(`Invalid vitamin '${vitamin}'`);
             }
-            let data = VITAMINS[vitamin];
-            let name = data.display;
-            let count = player.vitamins[vitamin];
+            const data = VITAMINS[vitamin];
+            const name = data.display;
+            const count = player.vitamins[vitamin];
             if (!count) {
-                return alert(`You don't have any of these.`);
+                return alert('You don\'t have any of these.');
             }
-            let vitaminModal = document.getElementById('vitaminModal');
+            const vitaminModal = document.getElementById('vitaminModal');
             vitaminModal.setAttribute('data-vitamin', vitamin);
             this.updateVitaminModal();
             openModal(vitaminModal);
         },
-        updateVitaminModal: function() {
-            let vitaminModal = document.getElementById('vitaminModal');
-            let vitamin = vitaminModal.getAttribute('data-vitamin');
-            let data = VITAMINS[vitamin];
-            let count = player.vitamins[vitamin];
+        updateVitaminModal: function () {
+            const vitaminModal = document.getElementById('vitaminModal');
+            const vitamin = vitaminModal.getAttribute('data-vitamin');
+            const data = VITAMINS[vitamin];
+            const count = player.vitamins[vitamin];
             document.getElementById('vitaminName').innerText = data.display;
             document.getElementById('vitaminCount').innerText = count;
             let vitaminPokemonHTML = '';
-            let list = player.getPokemon();
+            const list = player.getPokemon();
             for (let i = 0; i < list.length; i++) {
-                let poke = list[i];
-                vitaminPokemonHTML += `<li class="vitaminModalPokemon"><img src="${poke.image().party}"> <button class="button" onclick="userInteractions.useVitamin('${vitamin}', ${i})">${poke.getAppliedVitamins(data.stat)}/${poke.getMaxVitamins(data.stat)}</button></li>`
+                const poke = list[i];
+                vitaminPokemonHTML += `<li class="vitaminModalPokemon"><img src="${poke.image().party}"> <button class="button" onclick="userInteractions.useVitamin('${vitamin}', ${i})">${poke.getAppliedVitamins(data.stat)}/${poke.getMaxVitamins(data.stat)}</button></li>`;
             }
             document.getElementById('vitaminPokemon').innerHTML = vitaminPokemonHTML;
         },
-        useVitamin: function(vitamin, pokemonIndex) {
-            let vitaminData = VITAMINS[vitamin];
-            let count = player.vitamins[vitamin];
-            let poke = player.pokemons[pokemonIndex]
+        useVitamin: function (vitamin, pokemonIndex) {
+            const vitaminData = VITAMINS[vitamin];
+            const count = player.vitamins[vitamin];
+            const poke = player.pokemons[pokemonIndex];
             if (count <= 0 || !vitaminData || !poke) {
                 return;
             }
@@ -536,7 +536,7 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
             const routeData = ROUTES[player.settings.currentRegionId][player.settings.currentRouteId];
             if (routeData.trainer3 && routeData.trainer3.poke.length > 0) {
                 combatLoop.trainer3 = {
-                    name: routeData.trainer3.name, win: routeData.trainer3.win, reward: routeData.trainer3.reward, megaStone: routeData.trainer3.megaStone
+                    name: routeData.trainer3.name, win: routeData.trainer3.win, reward: routeData.trainer3.reward, megaStone: routeData.trainer3.megaStone,
                 };
                 combatLoop.trainer3Poke = Object.values({ ...routeData.trainer3.poke });
                 combatLoop.unpause();

--- a/src/modules/combat.js
+++ b/src/modules/combat.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-redeclare */
 import TYPES from './typeModifiers';
 import { RNG, flash, $ } from './utilities';
 import { POKEDEXFLAGS } from './data';

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -31,28 +31,28 @@ export const BALLRNG = {
 };
 
 export const VITAMINS = {
-  hpUp: {
-    display: 'HP Up',
-    stat: 'hp'
-  },
-  protein: {
-    display: 'Protein',
-    stat: 'attack'
-  },
-  iron: {
-    display: 'Iron',
-    stat: 'defense'
-  },
-  calcium: {
-    display: 'Calcium',
-    stat: 'sp atk'
-  },
-  zinc: {
-    display: 'Zinc',
-    stat: 'sp def'
-  },
-  carbos: {
-    display: 'Carbos',
-    stat: 'speed'
-  }
+    hpUp: {
+        display: 'HP Up',
+        stat: 'hp',
+    },
+    protein: {
+        display: 'Protein',
+        stat: 'attack',
+    },
+    iron: {
+        display: 'Iron',
+        stat: 'defense',
+    },
+    calcium: {
+        display: 'Calcium',
+        stat: 'sp atk',
+    },
+    zinc: {
+        display: 'Zinc',
+        stat: 'sp def',
+    },
+    carbos: {
+        display: 'Carbos',
+        stat: 'speed',
+    },
 };

--- a/src/modules/evolutions.ts
+++ b/src/modules/evolutions.ts
@@ -1,12 +1,5 @@
-//TODO: implement PokemonNameType
+// TODO: implement PokemonNameType
 type PokemonNameType = string;
-
-interface Evolution {
-    to: PokemonNameType;
-    requires: EvolutionType;
-}
-
-type EvolutionType = LevelEvolution | MegaEvolution | StoneEvolution;
 
 interface LevelEvolution {
     type: 'level';
@@ -21,6 +14,13 @@ interface MegaEvolution {
 interface StoneEvolution {
     type: 'stone';
     stone: string;
+}
+
+type EvolutionType = LevelEvolution | MegaEvolution | StoneEvolution;
+
+interface Evolution {
+    to: PokemonNameType;
+    requires: EvolutionType;
 }
 
 const EVOLUTIONS: Record<PokemonNameType, Evolution[]> = {

--- a/src/modules/player.js
+++ b/src/modules/player.js
@@ -258,10 +258,9 @@ export default (lastSave, appModel) => {
         },
         countPokedex: function (flag, exactMatch = false) {
             let counter = 0;
-            let i; let
-                pData;
+            let i;
             for (i in this.getPokedexData()) {
-                pData = this.getPokedexData()[i];
+                const pData = this.getPokedexData()[i];
                 if (exactMatch && flag == pData.flag) {
                     counter++;
                 } else if (!exactMatch && flag <= pData.flag) {

--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -88,33 +88,33 @@ export default (player) => {
         return this.level() >= 100;
     };
     Poke.prototype.tryUsingVitamin = function (stat) {
-      if (!this.canUseVitamin(stat)) {
-        return false;
-      }
-      this.appliedVitamins = this.appliedVitamins || {};
-      this.appliedVitamins[stat] = this.getAppliedVitamins(stat) + 1;
-      return true;
+        if (!this.canUseVitamin(stat)) {
+            return false;
+        }
+        this.appliedVitamins = this.appliedVitamins || {};
+        this.appliedVitamins[stat] = this.getAppliedVitamins(stat) + 1;
+        return true;
     };
     Poke.prototype.canUseVitamin = function (stat) {
-      return this.getAppliedVitamins(stat) < this.getMaxVitamins(stat);
+        return this.getAppliedVitamins(stat) < this.getMaxVitamins(stat);
     };
     Poke.prototype.getMaxVitamins = function (stat) {
-      return 5;
-    }
+        return 5;
+    };
     Poke.prototype.getAppliedVitamins = function (stat) {
-      return (this.appliedVitamins || {})[stat] || 0;
+        return (this.appliedVitamins || {})[stat] || 0;
     };
     Poke.prototype.getAppliedVitaminObject = function () {
-      let object = {};
-      let keys = Object.keys(this.appliedVitamins);
-      for (let i = 0; i < keys.length; i++) {
-        let vitamin = keys[i];
-        let applied = this.getAppliedVitamins(vitamin);
-        if (applied > 0) {
-          object[vitamin] = applied;
+        const object = {};
+        const keys = Object.keys(this.appliedVitamins);
+        for (let i = 0; i < keys.length; i++) {
+            const vitamin = keys[i];
+            const applied = this.getAppliedVitamins(vitamin);
+            if (applied > 0) {
+                object[vitamin] = applied;
+            }
         }
-      }
-      return object;
+        return object;
     };
 
     Poke.prototype.setHp = function (hp) { this.hp = hp; };

--- a/src/modules/routes.js
+++ b/src/modules/routes.js
@@ -2673,7 +2673,7 @@ const ROUTES = {
                     'Forest Badge': true
                 }
             }
-            
+
         }
         , sroute209: {
             name: 'Route 209'
@@ -2786,7 +2786,7 @@ const ROUTES = {
                 }
             }
         }
-         , ruinManiacCave: {
+        , ruinManiacCave: {
             name: 'Ruin Maniac Cave'
             , pokes: ['Hippopotas']
             , minLevel: 22
@@ -2866,9 +2866,9 @@ const ROUTES = {
         }
         , greatMarsh: {
             name: 'Great Marsh'
-            ,pokes: ['Paras', 'Psyduck', 'Golduck', 'Exeggcute', 'Tangela', 'Kangaskhan', 'Hoothoot', 'Noctowl', 'Marill', 'Yanma', 'Wooper', 'Quagsire', 'Shroomish', 'Azurill', 'Gulpin', 'Roselia', 'Kecleon', 'Tropius', 'Starly', 'Staravia', 'Bidoof', 'Bibarel', 'Budew', 'Skorupi', 'Drapion', 'Croagunk', 'Toxicroak', 'Carnivine']
-            ,minLevel: 20
-            ,maxLevel: 30,
+            , pokes: ['Paras', 'Psyduck', 'Golduck', 'Exeggcute', 'Tangela', 'Kangaskhan', 'Hoothoot', 'Noctowl', 'Marill', 'Yanma', 'Wooper', 'Quagsire', 'Shroomish', 'Azurill', 'Gulpin', 'Roselia', 'Kecleon', 'Tropius', 'Starly', 'Staravia', 'Bidoof', 'Bibarel', 'Budew', 'Skorupi', 'Drapion', 'Croagunk', 'Toxicroak', 'Carnivine']
+            , minLevel: 20
+            , maxLevel: 30,
             respawn: 'pastoriaCity',
             _unlock: {
                 badges: {
@@ -2890,9 +2890,9 @@ const ROUTES = {
         }
         , trophyGarden: {
             name: 'Trophy Garden'
-            ,pokes: ['Pikachu', 'Clefairy', 'Jigglypuff', 'Meowth', 'Chansey', 'Ditto', 'Eevee', 'Porygon', 'Pichu', 'Cleffa', 'Igglybuff', 'Marill', 'Azurill', 'Plusle', 'Minun', 'Roselia', 'Castform', 'Staravia', 'Kricketune', 'Bonsly', 'Mime Jr.', 'Happiny']
-            ,minLevel: 16
-            ,maxLevel: 18,
+            , pokes: ['Pikachu', 'Clefairy', 'Jigglypuff', 'Meowth', 'Chansey', 'Ditto', 'Eevee', 'Porygon', 'Pichu', 'Cleffa', 'Igglybuff', 'Marill', 'Azurill', 'Plusle', 'Minun', 'Roselia', 'Castform', 'Staravia', 'Kricketune', 'Bonsly', 'Mime Jr.', 'Happiny']
+            , minLevel: 16
+            , maxLevel: 18,
             respawn: 'pastoriaCity',
             _unlock: {
                 badges: {
@@ -3159,9 +3159,9 @@ const ROUTES = {
         }
         , sroute226: {
             name: 'Route 226'
-            ,pokes: ['Fearow', 'Raticate', 'Golduck', 'Machoke', 'Rattata', 'Spearow', 'Graveler', 'Wingull', 'Banette']
-            ,minLevel: 47
-            ,maxLevel: 53,
+            , pokes: ['Fearow', 'Raticate', 'Golduck', 'Machoke', 'Rattata', 'Spearow', 'Graveler', 'Wingull', 'Banette']
+            , minLevel: 47
+            , maxLevel: 53,
             respawn: 'snowpointCity',
             _unlock: {
                 badges: {
@@ -3171,9 +3171,9 @@ const ROUTES = {
         }
         , sroute227: {
             name: 'Route 227'
-            ,pokes: ['Rhydon', 'Camerupt', 'Fearow', 'Weezing', 'Golbat', 'Banette', 'Graveler', 'Rhyhorn', 'Skarmory', 'Numel']
-            ,minLevel: 24
-            ,maxLevel: 56,
+            , pokes: ['Rhydon', 'Camerupt', 'Fearow', 'Weezing', 'Golbat', 'Banette', 'Graveler', 'Rhyhorn', 'Skarmory', 'Numel']
+            , minLevel: 24
+            , maxLevel: 56,
             respawn: 'snowpointCity',
             _unlock: {
                 badges: {
@@ -3207,9 +3207,9 @@ const ROUTES = {
         }
         , sroute229: {
             name: 'Route 229'
-            ,pokes: ['Gloom', 'Weepinbell', 'Ledian', 'Illumise', 'Roselia', 'Oddish', 'Bellsprout', 'Scyther', 'Volbeat', 'Pinsir', 'Pidgey', 'Beautifly', 'Dustox']
-            ,minLevel: 20
-            ,maxLevel: 52,
+            , pokes: ['Gloom', 'Weepinbell', 'Ledian', 'Illumise', 'Roselia', 'Oddish', 'Bellsprout', 'Scyther', 'Volbeat', 'Pinsir', 'Pidgey', 'Beautifly', 'Dustox']
+            , minLevel: 20
+            , maxLevel: 52,
             respawn: 'snowpointCity',
             _unlock: {
                 badges: {
@@ -3219,9 +3219,9 @@ const ROUTES = {
         }
         , sroute230: {
             name: 'Route 230'
-            ,pokes: ['Gloom', 'Weepinbell', 'Floatzel', 'Oddish', 'Bellsprout', 'Golduck', 'Beautifly', 'Gastrodon', 'Dustox', 'Wingull']
-            ,minLevel: 18
-            ,maxLevel: 51,
+            , pokes: ['Gloom', 'Weepinbell', 'Floatzel', 'Oddish', 'Bellsprout', 'Golduck', 'Beautifly', 'Gastrodon', 'Dustox', 'Wingull']
+            , minLevel: 18
+            , maxLevel: 51,
             respawn: 'snowpointCity',
             _unlock: {
                 badges: {

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -1,15 +1,16 @@
 const { merge } = require('webpack-merge');
-const { serve, generateSourceMap, typecheck } = require('./parts');
+const parts = require('./parts');
 
 module.exports = ({ outputPath, host = 'localhost', port = 3000 }) => merge(
-    generateSourceMap({ tool: 'inline-module-source-map' }),
+    parts.generateSourceMap({ tool: 'inline-module-source-map' }),
 
-    typecheck({
+    parts.typecheck({
         async: true,
         logger: { infrastructure: 'console' },
     }),
+    parts.lint({ lintDirtyModulesOnly: true }),
 
-    serve({
+    parts.serve({
         host,
         port,
         static: outputPath,

--- a/webpack/parts.js
+++ b/webpack/parts.js
@@ -10,6 +10,8 @@ const { webpack, DefinePlugin } = require('webpack');
 const WebpackBar = require('webpackbar');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const ESLintPlugin = require('eslint-webpack-plugin');
+const { merge } = require('webpack-merge');
 
 const postcssLoader = (options) => ({
     loader: 'postcss-loader',
@@ -151,5 +153,14 @@ exports.useWebpackBar = (options) => ({
 exports.generateFavicon = (options) => ({
     plugins: [
         new FaviconsWebpackPlugin(options),
+    ],
+});
+
+exports.lint = (options = {}) => ({
+    plugins: [
+        new ESLintPlugin(merge(
+            { extensions: ['js', 'ts', 'vue'] },
+            options,
+        )),
     ],
 });

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -5,6 +5,7 @@ module.exports = (options) => merge(
     parts.typecheck({
         async: true,
     }),
+    parts.lint(),
     parts.minifyJavaScript(),
     parts.minifyCSS({ options: { preset: ['default'] } }),
     parts.compressFiles({


### PR DESCRIPTION
Runs eslint as part of the build process. Build will fail if there are any eslint errors, warnings will be displayed but allow the build to pass (there are currently ~150 warnings)

Also adds two new npm scripts:
`npm run lint` for running eslint without the overhead of an entire build
`npm run lint:fix` as above, but with the `--fix` flag to automatically fix whatever possible