### PR TITLE
chore: Create PokemonNameType

### DIFF
--- a/src/modules/db.ts
+++ b/src/modules/db.ts
@@ -19,7 +19,11 @@ interface PokedexData {
     id: number | string;
 }
 
-const POKEDEX: PokedexData[] = [
+function createPokemonArray<V extends string, T extends readonly PokedexData[] & Array<{name: V}>>(...args: T) {
+    return args;
+}
+
+const POKEDEX = createPokemonArray(
     {
         'name': 'Bulbasaur',
         'stats': {
@@ -16605,6 +16609,8 @@ const POKEDEX: PokedexData[] = [
         'exp': 61,
         'id': 828,
     },
-];
+);
+
+export type PokemonNameType = typeof POKEDEX[number]['name'];
 
 export default POKEDEX;

--- a/src/modules/evolutions.ts
+++ b/src/modules/evolutions.ts
@@ -1,5 +1,4 @@
-// TODO: implement PokemonNameType
-type PokemonNameType = string;
+import { PokemonNameType } from './db';
 
 interface LevelEvolution {
     type: 'level';
@@ -23,7 +22,7 @@ interface Evolution {
     requires: EvolutionType;
 }
 
-const EVOLUTIONS: Record<PokemonNameType, Evolution[]> = {
+const EVOLUTIONS: Partial<Record<PokemonNameType, Evolution[]>> = {
     'Bulbasaur': [
         { 'to': 'Ivysaur', 'requires': { 'type': 'level', 'level': '16' } },
     ],
@@ -268,7 +267,7 @@ const EVOLUTIONS: Record<PokemonNameType, Evolution[]> = {
     ],
     'Exeggcute': [
         { 'to': 'Exeggutor', 'requires': { 'type': 'stone', 'stone': 'leafStone' } },
-        { 'to': 'Alola Exeggutor', 'requires': { 'type': 'stone', 'stone': 'alolanStone' } },
+        { 'to': 'Alolan Exeggutor', 'requires': { 'type': 'stone', 'stone': 'alolanStone' } },
     ],
     'Cubone': [
         { 'to': 'Marowak', 'requires': { 'type': 'level', 'level': '28' } },


### PR DESCRIPTION
Copied from what we used to have on pokeclicker.

Seems to work, it already caught a bug with Alolan Exeggutor.

The type doesn't get applied to POKEDEX after we make it, I'm not sure if that is going to be a problem later.