### PR TITLE
chore: Build Performance

### DIFF
--- a/.github/workflows/attempt-build.yml
+++ b/.github/workflows/attempt-build.yml
@@ -5,6 +5,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: npm ci
-    - run: npm run build
+    - uses: actions/checkout@v2
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: npm-${{ hashFiles('package-lock.json') }}
+        restore-keys: npm-
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,9 +7,13 @@ const { getCommon } = require('./webpack/common');
 
 const outputPath = path.resolve(__dirname, folder || 'dist');
 const sourcePath = path.resolve(__dirname, 'src');
+const nodeModulesPath = path.resolve(__dirname, 'node_modules');
+const nodeCachePath = path.resolve(nodeModulesPath, '.cache');
 const options = {
     outputPath,
     sourcePath,
+    nodeModulesPath,
+    nodeCachePath,
     host,
     port,
 };

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -52,6 +52,8 @@ const getCommon = ({ outputPath, sourcePath, entries }) => (merge(
         },
     }),
 
+    parts.cache(),
+
     // Where to start looking for things to bundle
     { entry: ['./src'] },
 ));

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -1,14 +1,19 @@
 const { merge } = require('webpack-merge');
 const parts = require('./parts');
 
-module.exports = ({ outputPath, host = 'localhost', port = 3000 }) => merge(
+module.exports = ({
+    outputPath, nodeCachePath, host = 'localhost', port = 3000,
+}) => merge(
     parts.generateSourceMap({ tool: 'inline-module-source-map' }),
 
     parts.typecheck({
         async: true,
         logger: { infrastructure: 'console' },
     }),
-    parts.lint({ lintDirtyModulesOnly: true }),
+    parts.lint(merge(
+        { lintDirtyModulesOnly: true },
+        parts.lintCache(nodeCachePath),
+    )),
 
     parts.serve({
         host,

--- a/webpack/parts.js
+++ b/webpack/parts.js
@@ -12,6 +12,7 @@ const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const { merge } = require('webpack-merge');
+const path = require('path');
 
 const postcssLoader = (options) => ({
     loader: 'postcss-loader',
@@ -52,6 +53,10 @@ exports.loadTypescript = () => ({
                 test: /\.(j|t)sx?$/,
                 loader: 'babel-loader',
                 exclude: /node_modules/,
+                options: {
+                    cacheCompression: false,
+                    cacheDirectory: true,
+                },
             },
         ],
     },
@@ -163,4 +168,16 @@ exports.lint = (options = {}) => ({
             options,
         )),
     ],
+});
+
+exports.lintCache = (cacheRoot) => ({
+    cache: true,
+    cacheLocation: path.resolve(
+        cacheRoot,
+        '.eslintcache',
+    ),
+});
+
+exports.cache = (options = { type: 'filesystem' }) => ({
+    cache: options,
 });

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -1,11 +1,11 @@
 const { merge } = require('webpack-merge');
 const parts = require('./parts');
 
-module.exports = (options) => merge(
+module.exports = ({ nodeCachePath }) => merge(
     parts.typecheck({
         async: true,
     }),
-    parts.lint(),
+    parts.lint(parts.lintCache(nodeCachePath)),
     parts.minifyJavaScript(),
     parts.minifyCSS({ options: { preset: ['default'] } }),
     parts.compressFiles({


### PR DESCRIPTION
Enables some caching options in build tools, to hopefully get slightly faster build times.
I've attempted to test it, and it *looks* like this is in the region of 20-50% faster for the build commands, after a cache is built and there are no file changes.

Also added dependency caching to the pr check thing, though it doesn't look like it saves a huge amount of time. Having it cache node_modules to skip installing would be faster, but that involves some carefulness with making sure any dependency we add doesn't need to run some install script to work properly. Not worth the extra effort at this point, I think.
