### PR TITLE
fix: Storage Lag

### DIFF
--- a/src/components/PokemonList/PokeStorage.vue
+++ b/src/components/PokemonList/PokeStorage.vue
@@ -37,6 +37,7 @@
     <Paginated
       :get-key="(poke) => poke.pokeName()"
       :list="storage"
+      :page-size="15"
       list-id="storageList"
       list-class="manageTeamEnabled"
     >

--- a/src/components/PokemonList/PokeStorage.vue
+++ b/src/components/PokemonList/PokeStorage.vue
@@ -34,38 +34,44 @@
         Desc
       </option>
     </select>
-    <ul
-      v-if="!$store.state.loading"
-      id="storageList"
-      class="manageTeamEnabled"
+    <Paginated
+      :get-key="(poke) => poke.pokeName()"
+      :list="storage"
+      list-id="storageList"
+      list-class="manageTeamEnabled"
     >
-      <StoragePokemon
-        v-for="(poke, index) in $store.getters['pokemon/sortedStorage']"
-        :key="poke.pokeName()"
-        :ui="ui"
-        :index="index"
-        :poke="poke"
-      />
-    </ul>
+      <template
+        #item="{ item, index, offset }"
+      >
+        <StoragePokemon
+          :ui="ui"
+          :index="index + offset"
+          :poke="item"
+        />
+      </template>
+    </Paginated>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import StoragePokemon from './StoragePokemon.vue';
+import Paginated from '../common/Paginated';
 
 export default {
     components: {
         StoragePokemon,
+        Paginated,
     },
 
     props: {
         ui: { type: Object, required: true },
     },
 
-    data: function () {
-        return {
-            test: false,
-        };
+    computed: {
+        ...mapGetters({
+            storage: 'pokemon/sortedStorage',
+        }),
     },
 };
 </script>

--- a/src/components/PokemonList/StoragePokemon.vue
+++ b/src/components/PokemonList/StoragePokemon.vue
@@ -1,6 +1,7 @@
 <template>
   <li
     :id="`storagePoke${index}`"
+    class="is-flex is-justify-content-space-between"
   >
     <a
       href="#"
@@ -8,41 +9,36 @@
       :status="pokeStatus(poke)"
     >{{ poke.pokeName() }} ({{ poke.level() }})
     </a>
-    <br>
-    <button
-      class="pokeUpButton"
-      @click="ui.pokemonToUp(index, 'storage')"
+    <div
+      class="buttons are-small"
     >
-      <i
-        class="fa fa-arrow-up"
-        aria-hidden="true"
-      />
-    </button>
-    <button
-      class="pokeDownButton"
-      @click="ui.pokemonToDown(index, 'storage')"
-    >
-      <i
-        class="fa fa-arrow-down"
-        aria-hidden="true"
-      />
-    </button>
-    <button
-      class="pokeFirstButton"
-      @click="ui.pokemonToFirst(index, 'storage')"
-    >
-      #1
-    </button>
-    <button
-      class="toStorageButton"
-      @click="ui.moveToRoster(index)"
-    >
-      Active
-    </button>
+      <button
+        v-if="!isPinned(poke)"
+        class="button is-rounded"
+        @click="pin(poke)"
+      >
+        Pin
+      </button>
+      <button
+        v-else
+        class="button is-rounded"
+        @click="unpin(poke)"
+      >
+        Unpin
+      </button>
+      <button
+        class="button is-rounded"
+        @click="ui.moveToRoster(index)"
+      >
+        Active
+      </button>
+    </div>
   </li>
 </template>
 
 <script>
+import { mapMutations, mapGetters } from 'vuex';
+
 export default {
     props: {
         index: { type: Number, required: true },
@@ -50,7 +46,18 @@ export default {
         ui: { type: Object, required: true },
     },
 
+    computed: {
+        ...mapGetters({
+            isPinned: 'pokemon/isPinned',
+        }),
+    },
+
     methods: {
+        ...mapMutations({
+            pin: 'pokemon/pinStorage',
+            unpin: 'pokemon/unpinStorage',
+        }),
+
         /// Duplicate, refactor please.
         pokeStatus(poke) {
             if (poke.alive()) {

--- a/src/components/common/Paginated.vue
+++ b/src/components/common/Paginated.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="buttons">
+  <div class="buttons mb-0">
     <button
       class="button"
       :disabled="page === 1"

--- a/src/components/common/Paginated.vue
+++ b/src/components/common/Paginated.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="buttons">
+    <button
+      class="button"
+      :disabled="page === 1"
+      @click="page = 1"
+    >
+      &lt;&lt;
+    </button>
+    <button
+      class="button"
+      :disabled="page === 1"
+      @click="page--"
+    >
+      &lt;
+    </button>
+    <span class="mr-2 mb-2">{{ page }} / {{ totalPages }}</span>
+    <button
+      class="button"
+      :disabled="page === totalPages"
+      @click="page++"
+    >
+      &gt;
+    </button>
+    <button
+      class="button"
+      :disabled="page === totalPages"
+      @click="page = totalPages"
+    >
+      &gt;&gt;
+    </button>
+  </div>
+  <p>Showing {{ offset + 1 }} - {{ offset + pagedItems.length }} of {{ list.length }}</p>
+  <ul
+    :id="listId"
+    :class="listClass"
+  >
+    <slot name="listWrapper">
+      <template
+        v-for="(item, index) in pagedItems"
+        :key="getKey(item)"
+      >
+        <slot
+          name="item"
+          :item="item"
+          :index="index"
+          :offset="offset"
+        />
+      </template>
+    </slot>
+  </ul>
+</template>
+
+<script>
+const getOffset = (pageSize, page) => (page - 1) * pageSize;
+
+const getPage = (list, pageSize, page) => {
+    const offset = getOffset(pageSize, page);
+    return list.slice(offset, offset + pageSize);
+};
+
+export default {
+    props: {
+        list: { type: Array, required: true },
+        getKey: { type: Function, required: true },
+        pageSize: { type: Number, default: 10 },
+        listId: { type: String, default: '' },
+        listClass: { type: String, default: '' },
+    },
+
+    data: function () {
+        return {
+            page: 1,
+        };
+    },
+
+    computed: {
+        offset() {
+            return getOffset(this.pageSize, this.page);
+        },
+
+        pagedItems() {
+            return getPage(this.list, this.pageSize, this.page);
+        },
+
+        totalPages() {
+            return Math.ceil(this.list.length / this.pageSize);
+        },
+    },
+};
+</script>

--- a/src/modules/db.ts
+++ b/src/modules/db.ts
@@ -16614,3 +16614,12 @@ const POKEDEX = createPokemonArray(
 export type PokemonNameType = typeof POKEDEX[number]['name'];
 
 export default POKEDEX;
+
+export const pokedexMaps = POKEDEX.reduce((map, poke, index) => {
+    map.name[poke.name] = index;
+    map.id[poke.id] = index;
+    return map;
+}, {
+    name: {},
+    id: {},
+});

--- a/src/modules/player.js
+++ b/src/modules/player.js
@@ -463,6 +463,10 @@ export default (lastSave, appModel) => {
                 appModel.$store.state.pokemon.storage.forEach((poke, index) => {
                     localStorage.setItem(`storage${index}`, JSON.stringify(poke.save()));
                 });
+                localStorage.setItem(
+                    'pinnedStorage',
+                    JSON.stringify([...appModel.$store.state.pokemon.pinnedStorage]),
+                );
                 localStorage.setItem('ballsAmount', JSON.stringify(this.ballsAmount));
                 localStorage.setItem('battleItems', JSON.stringify(this.battleItems));
                 localStorage.setItem('vitamins', JSON.stringify(this.vitamins));
@@ -481,6 +485,7 @@ export default (lastSave, appModel) => {
             const saveData = JSON.stringify({
                 pokes: appModel.$store.state.pokemon.party.map((poke) => poke.save()),
                 storage: appModel.$store.state.pokemon.storage.map((poke) => poke.save()),
+                pinnedStorage: [...appModel.$store.state.pokemon.pinnedStorage],
                 pokedexData: this.getPokedexData(),
                 statistics: this.statistics,
                 settings: this.settings,
@@ -531,8 +536,8 @@ export default (lastSave, appModel) => {
                     storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel, appliedVitamins));
                 }
             });
-
-            appModel.$store.commit('pokemon/load', { party, storage });
+            const pinnedStorage = JSON.parse(localStorage.getItem('pinnedStorage'));
+            appModel.$store.commit('pokemon/load', { party, storage, pinnedStorage });
 
             if (JSON.parse(localStorage.getItem('ballsAmount'))) {
                 this.ballsAmount = JSON.parse(localStorage.getItem('ballsAmount'));
@@ -613,7 +618,8 @@ export default (lastSave, appModel) => {
                     storage.push(new Poke(pokeByName(pokeName), false, Number(exp), shiny, caughtAt, prestigeLevel, appliedVitamins));
                 });
 
-                appModel.$store.commit('pokemon/load', { party, storage });
+                const pinnedStorage = saveData.pinnedStorage;
+                appModel.$store.commit('pokemon/load', { party, storage, pinnedStorage });
 
                 this.ballsAmount = saveData.ballsAmount; // import from old spelling mistake
                 this.currencyAmount = saveData.currencyAmount;

--- a/src/store/modules/pokemon.js
+++ b/src/store/modules/pokemon.js
@@ -48,9 +48,10 @@ export default {
     },
 
     mutations: {
-        load(state, { party, storage }) {
+        load(state, { party, storage, pinnedStorage }) {
             state.party = party;
             state.storage = storage;
+            state.pinnedStorage = new Set(pinnedStorage);
         },
 
         add(state, poke) {

--- a/src/store/modules/pokemon.js
+++ b/src/store/modules/pokemon.js
@@ -1,4 +1,4 @@
-import POKEDEX from '../../modules/db';
+import { pokedexMaps } from '../../modules/db';
 
 const moveToFirst = (list, index) => [
     list[index],
@@ -23,7 +23,7 @@ const moveUp = (list, index) => [
 const cmpFunctions = {
     lvl: (lhs, rhs) => lhs.level() - rhs.level(),
     dex: (lhs, rhs) => {
-        const index = (p) => POKEDEX.findIndex((x) => x.name == p.pokeName());
+        const index = (p) => pokedexMaps.name[p.pokeName()];
         return index(lhs) - index(rhs);
     },
     vlv: (lhs, rhs) => lhs.level() - rhs.level() || lhs.avgAttack() - rhs.avgAttack(),

--- a/src/store/modules/pokemon.js
+++ b/src/store/modules/pokemon.js
@@ -39,6 +39,7 @@ export default {
         party: [],
         //
         storage: [],
+        pinnedStorage: new Set([]),
         storageSortDirection: 'asc',
         storageSortMethod: 'dex',
         //
@@ -131,6 +132,14 @@ export default {
             }
         },
 
+        pinStorage(state, poke) {
+            state.pinnedStorage.add(poke.pokeName());
+        },
+
+        unpinStorage(state, poke) {
+            state.pinnedStorage.delete(poke.pokeName());
+        },
+
         healAll(state) {
             state.party.forEach((poke) => poke.heal());
             state.storage.forEach((poke) => poke.heal());
@@ -145,8 +154,16 @@ export default {
                 cmpFunc = inverseCmp(cmpFunc);
             }
 
-            return state.storage.sort(cmpFunc);
+            const pinned = (poke) => state.pinnedStorage.has(poke.pokeName());
+            const pinCheck = (a, b) => Number(pinned(b)) - Number(pinned(a));
+
+            return state.storage.sort((a, b) => pinCheck(a, b) || cmpFunc(a, b));
         },
+
+        isPinned(state) {
+            return (poke) => state.pinnedStorage.has(poke.pokeName());
+        },
+
         // sortedParty,
         timeToHeal(state) {
             return Math.max(0, 30000 - (Date.now() - state.lastHeal));

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -12,7 +12,7 @@ html, body {
     grid-template-rows: 45% 25% 30%;
 }
 
-#gameContainer div {
+#gameContainer > div {
     border: 1px solid black;
 }
 


### PR DESCRIPTION
Splits the storage into pages, so we don't have to render everything at once
Creates a map of pokemon name -> pokedex index, so we don't have to search the entire pokedex for every pokemon
Replaces the up and down buttons in storage with a single "pin" (or "unpin") button, to save some space

Currently it always shows 15 pokemon per page, which looks ok on my screen, but might not be good on all screens. I'm no expert on layout, so I'll leave that to someone who knows better.

![Storage screenshot](https://imgur.com/i87H9Yu.png)