### PR TITLE
Improve storage styling on mobile

### DIFF
--- a/src/components/PokemonList/StoragePokemon.vue
+++ b/src/components/PokemonList/StoragePokemon.vue
@@ -1,7 +1,7 @@
 <template>
   <li
     :id="`storagePoke${index}`"
-    class="is-flex is-justify-content-space-between"
+    class="is-flex is-flex-wrap-wrap is-justify-content-space-between"
   >
     <a
       href="#"

--- a/src/components/common/Paginated.vue
+++ b/src/components/common/Paginated.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="buttons mb-0">
+  <div class="buttons are-small has-addons is-centered mb-0">
     <button
       class="button"
       :disabled="page === 1"
@@ -14,7 +14,7 @@
     >
       &lt;
     </button>
-    <span class="mr-2 mb-2">{{ page }} / {{ totalPages }}</span>
+    <span class="m-2">{{ page }} / {{ totalPages }}</span>
     <button
       class="button"
       :disabled="page === totalPages"

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -8,7 +8,7 @@ html, body {
     font-family: 'Lato', sans-serif;
     color: rgb(0, 0, 0);
     display: grid;
-    grid-template-columns: 18% 30% 30% 22%;
+    grid-template-columns: minmax(210px, 18%) 30% 30% 22%;
     grid-template-rows: 45% 25% 30%;
 }
 


### PR DESCRIPTION
Reduces size of page navigation buttons, and should keep them all on one line

Makes the pin/active buttons break onto a new line together, if there is not enough space. This doesn't happen to all at the same time though, so there might be pokemon with a long name or just a screen size in the sweet spot making some buttons on a new line but not the others. Mobile seems small enough for all buttons to be on a new line though.

Screenshots at various screen sizes:

![Large](https://imgur.com/s0PolsU.png)
![Medium](https://imgur.com/Z5ack7r.png)
![Small](https://imgur.com/7WZ2eby.png)
![Mobile](https://i.imgur.com/4HCw30k.jpg)