### PR TITLE
Add search to pokemon storage

### DIFF
--- a/src/components/PokemonList/PokeStorage.vue
+++ b/src/components/PokemonList/PokeStorage.vue
@@ -2,10 +2,28 @@
   <div
     id="storageBox"
   >
-    <input
-      id="autoSort"
-      type="checkbox"
-    ><label for="autoSort"><span class="checkDescription">Auto sort</span></label><br>
+    <label class="checkbox">
+      <input
+        id="autoSort"
+        type="checkbox"
+      >
+      Auto sort
+    </label>
+    <div class="field has-addons mb-1">
+      <p class="control">
+        <input
+          v-model="nameSearchText"
+          class="input is-small"
+          type="text"
+          placeholder="Enter poke name"
+        >
+      </p>
+      <p class="control">
+        <a class="button is-small is-static">
+          Search
+        </a>
+      </p>
+    </div>
     <select
       id="pokeSortOrderSelect"
       v-model="$store.state.pokemon.storageSortMethod"
@@ -38,6 +56,7 @@
       :get-key="(poke) => poke.pokeName()"
       :list="storage"
       :page-size="15"
+      :filter="filter"
       list-id="storageList"
       list-class="manageTeamEnabled"
     >
@@ -59,6 +78,11 @@ import { mapGetters } from 'vuex';
 import StoragePokemon from './StoragePokemon.vue';
 import Paginated from '../common/Paginated';
 
+const nameFilter = (name) => {
+    const lowerName = name.toLowerCase();
+    return (poke) => poke.pokeName().toLowerCase().includes(lowerName);
+};
+
 export default {
     components: {
         StoragePokemon,
@@ -69,10 +93,20 @@ export default {
         ui: { type: Object, required: true },
     },
 
+    data: function () {
+        return {
+            nameSearchText: '',
+        };
+    },
+
     computed: {
         ...mapGetters({
             storage: 'pokemon/sortedStorage',
         }),
+
+        filter() {
+            return nameFilter(this.nameSearchText);
+        },
     },
 };
 </script>

--- a/src/components/common/Paginated.vue
+++ b/src/components/common/Paginated.vue
@@ -30,7 +30,15 @@
       &gt;&gt;
     </button>
   </div>
-  <p>Showing {{ offset + 1 }} - {{ offset + pagedItems.length }} of {{ list.length }}</p>
+  <p>
+    Showing
+    {{ offset + 1 }}
+    -
+    {{ offset + pagedItems.length }}
+    of
+    {{ list.length }}
+    <span v-if="isFiltered">(filtered)</span>
+  </p>
   <ul
     :id="listId"
     :class="listClass"
@@ -66,6 +74,7 @@ export default {
         pageSize: { type: Number, default: 10 },
         listId: { type: String, default: '' },
         listClass: { type: String, default: '' },
+        filter: { type: Function, default: null },
     },
 
     data: function () {
@@ -79,12 +88,30 @@ export default {
             return getOffset(this.pageSize, this.page);
         },
 
+        filteredList() {
+            return this.filter
+                ? this.list.filter(this.filter)
+                : this.list;
+        },
+
         pagedItems() {
-            return getPage(this.list, this.pageSize, this.page);
+            return getPage(this.filteredList, this.pageSize, this.page);
         },
 
         totalPages() {
-            return Math.max(1, Math.ceil(this.list.length / this.pageSize));
+            return Math.max(1, Math.ceil(this.filteredList.length / this.pageSize));
+        },
+
+        isFiltered() {
+            return this.filteredList.length < this.list.length;
+        },
+    },
+
+    watch: {
+        totalPages(newMax) {
+            if (this.page > newMax) {
+                this.page = newMax;
+            }
         },
     },
 };

--- a/src/styles/bulma.custom.scss
+++ b/src/styles/bulma.custom.scss
@@ -5,6 +5,7 @@
 @import '~bulma/sass/utilities/_all.sass';
 @import '~bulma/sass/base/_all.sass';
 @import '~bulma/sass/helpers/_all.sass';
+@import "~bulma/sass/form/_all.sass";
 @import '~bulma/sass/grid/columns.sass';
 
 @import '~bulma/sass/elements/button.sass';


### PR DESCRIPTION
Adds a case-insensitive partial name search box to the storage
It will make sure you don't end up on a page past the end of the filtered results, eg if you are on page 5 and the filter reduces the number of pages to 2, you will be sent to page 2 automatically

Also adds some text when a filter is active, in case someone forgets they have it filtered and can't find a pokemon.

This has been added as a feature of the Paginated component, you just need to pass a function into it that can be used in the Array `filter` method, ie a function of type `ListItem -> boolean`, where `ListItem` is the type of thing in the list Paginated is being passed.

![Example](https://imgur.com/C4VEfPO.png)