### PR TITLE
Many Johto Fixes!

### DIFF
--- a/src/modules/routes.ts
+++ b/src/modules/routes.ts
@@ -955,7 +955,7 @@ const ROUTES: Routes = {
             rarePokes: [],
             superRare: [],
         },
-        NewBarkTown: {
+        newBarkTown: {
             name: 'New Bark Town',
             town: true,
             prof: {
@@ -996,14 +996,14 @@ const ROUTES: Routes = {
                 ],
             },
         },
-        jroute29: {
+        johtoroute29: {
             name: 'Route 29',
             pokes: ['Pidgey', 'Rattata', 'Sentret', 'Hoothoot', 'Hoppip', 'Chikorita', 'Cyndaquil', 'Totodile'],
             minLevel: 2,
             maxLevel: 5,
-            respawn: 'starter2',
+            respawn: 'newBarkTown',
         },
-        jroute46: {
+        johtoroute46: {
             name: 'Route 46',
             pokes: ['Rattata', 'Spearow', 'Jigglypuff', 'Geodude', 'Phanpy'],
             minLevel: 2,
@@ -1014,14 +1014,14 @@ const ROUTES: Routes = {
             name: 'Cherrygrove City',
             town: true,
         },
-        jroute30: {
+        johtoroute30: {
             name: 'Route 30',
             pokes: ['Caterpie', 'Metapod', 'Weedle', 'Kakuna', 'Pidgey', 'Rattata', 'Zubat', 'Poliwag', 'Hoothoot', 'Ledyba', 'Spinarak', 'Hoppip'],
             minLevel: 2,
             maxLevel: 5,
             respawn: 'cherrygroveCity',
         },
-        jroute31: {
+        johtoroute31: {
             name: 'Route 31',
             pokes: ['Caterpie', 'Metapod', 'Weedle', 'Kakuna', 'Pidgey', 'Rattata', 'Zubat', 'Poliwag', 'Bellsprout', 'Gastly', 'Hoothoot', 'Ledyba', 'Spinarak', 'Hoppip'],
             minLevel: 3,
@@ -1030,7 +1030,7 @@ const ROUTES: Routes = {
         },
         darkCave: {
             name: 'Dark Cave',
-            pokes: ['Zubat', 'Geodude', 'Graveler', 'Wobbuffet', 'Dunsparce', 'Teddiursa', 'Ursaring'],
+            pokes: ['Zubat', 'Geodude', 'Graveler', 'Krabby', 'Wobbuffet', 'Dunsparce', 'Shuckle', 'Teddiursa', 'Ursaring'],
             minLevel: 2,
             maxLevel: 30,
             respawn: 'cherrygroveCity',
@@ -1094,7 +1094,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute32: {
+        johtoroute32: {
             name: 'Route 32',
             pokes: ['Pidgey', 'Rattata', 'Ekans', 'Zubat', 'Bellsprout', 'Gastly', 'Hoothoot', 'Mareep', 'Hoppip', 'Wooper'],
             minLevel: 4,
@@ -1133,8 +1133,8 @@ const ROUTES: Routes = {
         unionCave: {
             name: 'Union Cave',
             pokes: ['Rattata', 'Raticate', 'Sandshrew', 'Zubat', 'Golbat', 'Geodude', 'Onix', 'Wooper', 'Quagsire', 'Lapras'],
-            minLevel: 6,
-            maxLevel: 24,
+            minLevel: 4,
+            maxLevel: 23,
             respawn: 'violetCity',
             _unlock: {
                 badges: {
@@ -1142,7 +1142,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute33: {
+        johtoroute33: {
             name: 'Route 33',
             pokes: ['Rattata', 'Spearow', 'Ekans', 'Zubat', 'Geodude', 'Hoppip'],
             minLevel: 6,
@@ -1156,10 +1156,10 @@ const ROUTES: Routes = {
         },
         slowpokeWell: {
             name: 'Slowpoke Well',
-            pokes: ['Zubat', 'Golbat', 'Slowpoke', 'Slowking'],
+            pokes: ['Zubat', 'Golbat', 'Slowpoke'],
             minLevel: 5,
-            maxLevel: 25,
-            respawn: 'violetCity',
+            maxLevel: 23,
+            respawn: 'azaleaTown',
             _unlock: {
                 badges: {
                     'Zephyr Badge': true,
@@ -1230,7 +1230,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute34: {
+        johtoroute34: {
             name: 'Route 34',
             pokes: ['Pidgey', 'Rattata', 'Jigglypuff', 'Abra', 'Drowzee', 'Ditto', 'Hoothoot', 'Snubbull'],
             minLevel: 10,
@@ -1248,6 +1248,11 @@ const ROUTES: Routes = {
             minLevel: 5,
             maxLevel: 5,
             respawn: 'azaleaTown',
+            _unlock: {
+                badges: {
+                    'Hive Badge': true,
+                },
+            },
         },
         goldenrodCity: {
             name: 'Goldenrod City',
@@ -1299,7 +1304,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute35: {
+        johtoroute35: {
             name: 'Route 35',
             pokes: ['Pidgey', 'Nidoran F', 'Nidoran M', 'Jigglypuff', 'Psyduck', 'Growlithe', 'Abra', 'Drowzee', 'Ditto', 'Hoothoot', 'Yanma', 'Snubbull'],
             minLevel: 10,
@@ -1307,7 +1312,7 @@ const ROUTES: Routes = {
             respawn: 'goldenrodCity',
             _unlock: {
                 badges: {
-                    'Plain Badge': true,
+                    'Hive Badge': true,
                 },
             },
         },
@@ -1315,6 +1320,18 @@ const ROUTES: Routes = {
             name: 'National Park',
             pokes: ['Caterpie', 'Metapod', 'Butterfree', 'Weedle', 'Kakuna', 'Beedrill', 'Pidgey', 'Nidoran F', 'Nidoran M', 'Paras', 'Venonat', 'Psyduck', 'Scyther', 'Pinsir', 'Hoothoot', 'Ledyba', 'Spinarak', 'Sunkern'],
             minLevel: 10,
+            maxLevel: 17,
+            respawn: 'goldenrodCity',
+            _unlock: {
+                badges: {
+                    'Hive Badge': true,
+                },
+            },
+        },
+        johtoroute36: {
+            name: 'Route 36',
+            pokes: ['Pidgey', 'Nidoran F', 'Nidoran M', 'Vulpix', 'Growlithe', 'Bellsprout', 'Gastly', 'Hoothoot', 'Ledyba', 'Spinarak', 'Stantler', 'Sudowoodo'],
+            minLevel: 4,
             maxLevel: 15,
             respawn: 'goldenrodCity',
             _unlock: {
@@ -1323,19 +1340,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute36: {
-            name: 'Route 36',
-            pokes: ['Pidgey', 'Nidoran F', 'Nidoran M', 'Vulpix', 'Growlithe', 'Bellsprout', 'Gastly', 'Hoothoot', 'Ledyba', 'Spinarak', 'Stantler', 'Sudowoodo'],
-            minLevel: 13,
-            maxLevel: 20,
-            respawn: 'goldenrodCity',
-            _unlock: {
-                badges: {
-                    'Plain Badge': true,
-                },
-            },
-        },
-        jroute37: {
+        johtoroute37: {
             name: 'Route 37',
             pokes: ['Pidgey', 'Pidgeotto', 'Vulpix', 'Growlithe', 'Hoothoot', 'Noctowl', 'Ledyba', 'Ledian', 'Spinarak', 'Ariados', 'Stantler'],
             minLevel: 13,
@@ -1368,7 +1373,7 @@ const ROUTES: Routes = {
         },
         burnedTower: {
             name: 'Burned Tower',
-            pokes: ['Rattata', 'Raticate', 'Zubat', 'Koffing', 'Weezing', 'Magmar'],
+            pokes: ['Rattata', 'Raticate', 'Zubat', 'Krabby', 'Koffing', 'Weezing', 'Magmar', 'Shuckle'],
             minLevel: 13,
             maxLevel: 16,
             respawn: 'goldenrodCity',
@@ -1386,11 +1391,11 @@ const ROUTES: Routes = {
             respawn: 'goldenrodCity',
             _unlock: {
                 badges: {
-                    'Plain Badge': true,
+                    'Glacier Badge': true,
                 },
             },
         },
-        jroute38: {
+        johtoroute38: {
             name: 'Route 38',
             pokes: ['Pidgeotto', 'Rattata', 'Raticate', 'Meowth', 'Magnemite', 'Farfetchd', 'Tauros', 'Noctowl', 'Snubbull', 'Miltank'],
             minLevel: 13,
@@ -1402,11 +1407,11 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute39: {
+        johtoroute39: {
             name: 'Route 39',
             pokes: ['Pidgeotto', 'Rattata', 'Raticate', 'Meowth', 'Magnemite', 'Farfetchd', 'Tauros', 'Noctowl', 'Miltank'],
             minLevel: 15,
-            maxLevel: 16,
+            maxLevel: 17,
             respawn: 'ecruteakCity',
             _unlock: {
                 badges: {
@@ -1465,9 +1470,9 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute40: {
+        johtoroute40: {
             name: 'Route 40',
-            pokes: ['Tentacool', 'Tentacruel'],
+            pokes: ['Tentacool', 'Tentacruel', 'Krabby', 'Shuckle'],
             minLevel: 15,
             maxLevel: 24,
             respawn: 'olivineCity',
@@ -1477,15 +1482,15 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute41: {
+        johtoroute41: {
             name: 'Route 41',
             pokes: ['Mantine', 'Tentacool', 'Tentacruel'],
-            minLevel: 20,
+            minLevel: 15,
             maxLevel: 24,
             respawn: 'cianwoodCity',
             _unlock: {
                 badges: {
-                    'Storm Badge': true,
+                    'Mineral Badge': true,
                 },
             },
         },
@@ -1497,7 +1502,7 @@ const ROUTES: Routes = {
             respawn: 'cianwoodCity',
             _unlock: {
                 badges: {
-                    'Storm Badge': true,
+                    'Glacier Badge': true,
                 },
             },
         },
@@ -1518,11 +1523,11 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute47: {
+        johtoroute47: {
             name: 'Route 47',
             pokes: ['Raticate', 'Spearow', 'Fearow', 'Gloom', 'Farfetchd', 'Ditto', 'Noctowl', 'Miltank'],
-            minLevel: 40,
-            maxLevel: 43,
+            minLevel: 31,
+            maxLevel: 40,
             respawn: 'cianwoodCity',
             _unlock: {
                 badges: {
@@ -1530,11 +1535,11 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute48: {
+        johtoroute48: {
             name: 'Route 48',
             pokes: ['Fearow', 'Vulpix', 'Gloom', 'Diglett', 'Growlithe', 'Farfetchd', 'Tauros', 'Hoppip', 'Girafarig'],
-            minLevel: 40,
-            maxLevel: 43,
+            minLevel: 20,
+            maxLevel: 25,
             respawn: 'cianwoodCity',
             _unlock: {
                 badges: {
@@ -1542,7 +1547,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute42: {
+        johtoroute42: {
             name: 'Route 42',
             pokes: ['Rattata', 'Raticate', 'Spearow', 'Fearow', 'Ekans', 'Arbok', 'Zubat', 'Golbat', 'Mankey', 'Mareep', 'Flaaffy', 'Marill'],
             minLevel: 13,
@@ -1557,7 +1562,7 @@ const ROUTES: Routes = {
         mtMortar: {
             name: 'Mt. Mortar',
             pokes: ['Rattata', 'Raticate', 'Zubat', 'Golbat', 'Machop', 'Machoke', 'Geodude', 'Graveler', 'Marill'],
-            minLevel: 15,
+            minLevel: 14,
             maxLevel: 32,
             respawn: 'ecruteakCity',
             _unlock: {
@@ -1596,7 +1601,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute43: {
+        johtoroute43: {
             name: 'Route 43',
             pokes: ['Pidgeotto', 'Raticate', 'Venonat', 'Venomoth', 'Farfetchd', 'Sentret', 'Furret', 'Noctowl', 'Mareep', 'Flaaffy', 'Girafarig'],
             minLevel: 15,
@@ -1611,7 +1616,7 @@ const ROUTES: Routes = {
         lakeofRage: {
             name: 'Lake of Rage',
             pokes: ['Gyarados', 'Magikarp'],
-            minLevel: 30,
+            minLevel: 10,
             maxLevel: 30,
             respawn: 'mahoganyTown',
             _unlock: {
@@ -1620,7 +1625,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute44: {
+        johtoroute44: {
             name: 'Route 44',
             pokes: ['Poliwag', 'Poliwhirl', 'Bellsprout', 'Weepinbell', 'Lickitung', 'Tangela'],
             minLevel: 22,
@@ -1634,9 +1639,9 @@ const ROUTES: Routes = {
         },
         icePath: {
             name: 'Ice Path',
-            pokes: ['Zubat', 'Golbat', 'Jynx', 'Sneasel', 'Swinub', 'Delibird'],
-            minLevel: 21,
-            maxLevel: 24,
+            pokes: ['Zubat', 'Golbat', 'Krabby', 'Jynx', 'Shuckle', 'Sneasel', 'Swinub', 'Delibird'],
+            minLevel: 20,
+            maxLevel: 26,
             respawn: 'mahoganyTown',
             _unlock: {
                 badges: {
@@ -1648,19 +1653,7 @@ const ROUTES: Routes = {
             name: 'Dragons Den',
             pokes: ['Magikarp', 'Dratini'],
             minLevel: 10,
-            maxLevel: 14,
-            respawn: 'mahoganyTown',
-            _unlock: {
-                badges: {
-                    'Glacier Badge': true,
-                },
-            },
-        },
-        jroute45: {
-            name: 'Route 45',
-            pokes: ['Geodude', 'Graveler', 'Gligar', 'Teddiursa', 'Skarmory', 'Phanpy', 'Donphan'],
-            minLevel: 20,
-            maxLevel: 27,
+            maxLevel: 19,
             respawn: 'mahoganyTown',
             _unlock: {
                 badges: {
@@ -1687,7 +1680,19 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute26: {
+        johtoroute45: {
+            name: 'Route 45',
+            pokes: ['Geodude', 'Graveler', 'Gligar', 'Teddiursa', 'Skarmory', 'Phanpy', 'Donphan'],
+            minLevel: 20,
+            maxLevel: 30,
+            respawn: 'mahoganyTown',
+            _unlock: {
+                badges: {
+                    'Glacier Badge': true,
+                },
+            },
+        },
+        johtoroute27: {
             name: 'Route 27',
             pokes: ['Raticate', 'Arbok', 'Sandslash', 'Ponyta', 'Doduo', 'Dodrio', 'Noctowl', 'Quagsire'],
             minLevel: 28,
@@ -1699,7 +1704,7 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute27: {
+        johtoroute26: {
             name: 'Route 26',
             pokes: ['Raticate', 'Arbok', 'Sandslash', 'Ponyta', 'Doduo', 'Dodrio', 'Noctowl', 'Quagsire'],
             minLevel: 28,
@@ -1711,7 +1716,31 @@ const ROUTES: Routes = {
                 },
             },
         },
-        jroute28: {
+        johtoroute7: {
+            name: 'Route 7',
+            pokes: ['Rattata', 'Raticate', 'Spearow', 'Vulpix', 'Jigglypuff', 'Meowth', 'Persian', 'Growlithe', 'Abra', 'Murkrow', 'Snubbull', 'Houndour'],
+            minLevel: 15,
+            maxLevel: 19,
+            respawn: 'NewBarkTown',
+            _unlock: {
+                badges: {
+                    'Rising Badge': true,
+                },
+            },
+        },
+        johtoroute16: {
+            name: 'Route 16',
+            pokes: ['Fearow', 'Grimer', 'Muk', 'Murkrow', 'Slugma'],
+            minLevel: 26,
+            maxLevel: 32,
+            respawn: 'NewBarkTown',
+            _unlock: {
+                badges: {
+                    'Rising Badge': true,
+                },
+            },
+        },
+        johtoroute28: {
             name: 'Route 28',
             pokes: ['Ponyta', 'Tangela', 'Ursaring', 'Donphan', 'Rapidash', 'Arbok', 'Doduo', 'Dodrio', 'Sneasel', 'Poliwhirl', 'Golbat'],
             minLevel: 39,
@@ -1764,10 +1793,10 @@ const ROUTES: Routes = {
             pokes: ['Caterpie', 'Metapod', 'Butterfree', 'Weedle', 'Kakuna', 'Beedrill', 'Spearow', 'Ekans', 'Exeggcute', 'Hoothoot', 'Noctowl', 'Spinarak', 'Ledyba', 'Aipom', 'Pineco', 'Heracross', 'Shuckle', 'Raikou', 'Entei', 'Suicune', 'Celebi'],
             minLevel: 10,
             maxLevel: 10,
-            respawn: 'blackthornCity',
+            respawn: 'azaleaTown',
             _unlock: {
                 badges: {
-                    'Rising Badge': true,
+                    'Hive Badge': true,
                 },
             },
         },


### PR DESCRIPTION
Change every jroute into a johtoroute.
Change starter2 to newbarktown.
Adjust many levels.
Remove Slowking from Slowpokewell awaiting the evolution fix.
Add Hive Badge requirement to Day Care Center, fitting it's location just south of Goldenrod.
Make route 35 and National Park available before obtaining Plain Badge.
Added routes 7 and 16 to make Houndour, Slugma and Murkrow available. Unlock with Rising Badge and respawn at New Bark. (These are technically Kanto routes. The gen 2 version of Kanto.)
Returned the rock smash mons (Shuckle and Krabby) to Dark Cave, Burned Tower, route 40, Ice Path. Remove Shuckle from roamers/headbutt.
Changed Tin Tower requirement to Glacier badge, which is the point where one would obtain the Rainbow Wing.
Changed route 41 to open with Mineral Badge. It just makes sense.
Changed Whirl Islands requirement to Glacier badge, which is the point where one would obtain the Silver Wing.
Move route 45 down and unlock it with Glacier Badge.
Changed Headbutt to respawn at Azalea and require Hive Badge. The Headbutt TM is obtained in Ilex Forest.