### PR TITLE
Notifications

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,5 +11,6 @@
         <span id="popupText">Test text</span>
     </div>
 
+    <div id='notifications'></div>
 </body>
 </html>

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,3 +3,4 @@
 @import './styles/style.scss';
 @import './styles/icons.scss';
 @import './styles/types.scss';
+@import './styles/notifications.scss';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import Poke, { pokeImage } from './modules/poke';
 import setupModals from './modules/modalEvents';
 import POKEDEX from './modules/db';
 import * as utilities from './modules/utilities';
+import notify from './modules/notify';
 // include styles in webpack bundle
 import './index.scss';
 
@@ -66,6 +67,7 @@ if (process.env.NODE_ENV === 'development') {
         POKEDEX,
         pokeImage,
         ...utilities,
+        notify,
     };
 } else {
     // Otherwise, just the things we need to make the game run

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -7,6 +7,7 @@ import { POKEDEXFLAGS, VITAMINS } from './data';
 import { openModal, closeModal } from './modalEvents';
 import Poke from './poke';
 import POKEDEX from './db';
+import notify from './notify';
 
 export default (player, combatLoop, enemy, town, story, appModel) => {
     let dom;
@@ -15,19 +16,19 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
 
         changeRoute: function (newRouteId, force = false) {
             if (!force && player.alivePokeIndexes().length == 0) {
-                alert('It is too dangerous to travel without a POKEMON.');
+                notify('It is too dangerous to travel without a POKEMON.');
                 return false;
             }
             if (combatLoop.prof || combatLoop.prof1 || combatLoop.prof2 || combatLoop.prof3) {
-                alert('You cannot run away from a PROFESSOR battle.');
+                notify('You cannot run away from a PROFESSOR battle.');
                 return false;
             }
             if (combatLoop.gymLeader || combatLoop.gymLeader1 || combatLoop.gymLeader2 || combatLoop.gymLeader3) {
-                alert('You cannot run away from a GYM LEADER battle.');
+                notify('You cannot run away from a GYM LEADER battle.');
                 return false;
             }
             if (!player.routeUnlocked(player.settings.currentRegionId, newRouteId)) {
-                alert('You cannot go there yet.');
+                notify('You cannot go there yet.');
                 return false;
             }
             player.settings.currentRouteId = newRouteId;

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -390,7 +390,7 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
                 player.addPoke(new Poke(pokeByName('Charmander'), 50));
                 player.secretCodes.charmander = true;
             } else {
-                alert('Code Invalid or Already Claimed');
+                notify('Code Invalid or Already Claimed', { type: 'danger' });
             }
         },
         viewBadges: function () {

--- a/src/modules/notify.ts
+++ b/src/modules/notify.ts
@@ -1,0 +1,56 @@
+// Creates a bulma notification
+// https://bulma.io/documentation/elements/notification/
+
+type NotifOptions = {
+    // color scheme, see documentation link
+    type: 'primary' | 'link' | 'info' | 'success' | 'warning' | 'danger',
+    // also part of color scheme
+    light: boolean,
+    // how long to show the notification for
+    duration: number,
+    // is the content being provided html or plain text?
+    isHtml: boolean,
+    // show an X in the corner to dismiss?
+    closeButton: boolean,
+}
+
+const defaultOptions: NotifOptions = {
+    type: 'info',
+    light: true,
+    duration: 5000,
+    isHtml: false,
+    closeButton: true,
+};
+
+const notifContainer = document.getElementById('notifications');
+
+export default function notify(content: string, _options: Partial<NotifOptions> = {}): void {
+    const options = {
+        ...defaultOptions,
+        ..._options,
+    };
+
+    const notif = document.createElement('div');
+    const contentContainer = document.createElement('div');
+    if (options.isHtml) {
+        contentContainer.innerHTML = content;
+    } else {
+        contentContainer.innerText = content;
+    }
+
+    notif.classList.add('notification', `is-${options.type}`);
+    if (options.light) {
+        notif.classList.add('is-light');
+    }
+
+    if (options.closeButton) {
+        const close = document.createElement('button');
+        close.classList.add('delete');
+        close.addEventListener('click', () => notif.remove());
+        notif.appendChild(close);
+    }
+
+    notif.appendChild(contentContainer);
+    notifContainer.appendChild(notif);
+    setTimeout(() => notif.remove(), options.duration);
+}

--- a/src/styles/bulma.custom.scss
+++ b/src/styles/bulma.custom.scss
@@ -11,6 +11,7 @@
 @import '~bulma/sass/elements/button.sass';
 @import '~bulma/sass/elements/title.sass';
 @import '~bulma/sass/elements/icon.sass';
+@import '~bulma/sass/elements/notification.sass';
 
 @import '~bulma/sass/components/card.sass';
 @import '~bulma/sass/components/modal.sass';

--- a/src/styles/notifications.scss
+++ b/src/styles/notifications.scss
@@ -1,0 +1,13 @@
+#notifications {
+    position: fixed;
+    top: 5px;
+    left: 5px;
+
+    width: 20%;
+    height: 100vh;
+    overflow: hidden;
+
+    .notification {
+        border: 2px solid darkslategray;
+    }
+}


### PR DESCRIPTION
Adds a `notify` function you can use instead of alerts.
I've only replaced a few alerts as an example of how to use it.

Based on the [bulma notification element](https://bulma.io/documentation/elements/notification/), see link for color options.
The notify function accepts some configuration options as the second argument, details are at the top of the notify.ts file, and an example of providing a type of 'danger' for red coloring on the invalid secret code message.

I've also made `notify` available in dev console, so you can try things out there if you want to.

Notifications default to the light info color scheme, and last for 5 seconds.