### PR TITLE
Fix enemy prestige

### DIFF
--- a/src/modules/enemy.js
+++ b/src/modules/enemy.js
@@ -10,6 +10,7 @@ export default (starter, player, Poke) => {
         level,
         false,
         Math.random() < (1 / (2 ** 13)),
+        false,
         prestigeLevel,
     );
 


### PR DESCRIPTION
The `Poke` constructor call was missing a parameter.