### PR TITLE
[FIX] Allow battling gym leader without requirement

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -777,7 +777,7 @@ export default (player, combatLoop, enemy, town, story, appModel) => {
         gymLeaderBattle: function () {
             const routeData = ROUTES[player.settings.currentRegionId][player.settings.currentRouteId].gym;
             closeModal(document.getElementById('gymModal'));
-            if (routeData.gymLeader && routeData.gymLeader.poke.length > 0 && player.wins[routeData.gymLeader.req]) {
+            if (routeData.gymLeader && routeData.gymLeader.poke.length > 0 && (!routeData.gymLeader.req || player.wins[routeData.gymLeader.req])) {
                 combatLoop.gymLeader = { name: routeData.gymLeader.name, badge: routeData.gymLeader.badge, win: routeData.gymLeader.win };
                 combatLoop.gymLeaderPoke = Object.values({ ...routeData.gymLeader.poke });
                 combatLoop.unpause();


### PR DESCRIPTION
Without an explicit requirement, the game fails to recognize that the gym leader should be reachable.