### PR TITLE
Alternative colors for current route

### DIFF
--- a/src/modules/data.ts
+++ b/src/modules/data.ts
@@ -12,9 +12,11 @@ export const COLORS: Record<string, Record<string, string>> = {};
 COLORS['route'] = {};
 COLORS['route']['locked'] = 'rgb(255, 0, 0)';
 COLORS['route']['unlocked'] = 'rgb(255, 255, 255)';
-COLORS['route']['current'] = 'rgb(139, 69, 19)';
 COLORS['route']['caughtAll'] = 'rgb(0, 127, 0)';
 COLORS['route']['caughtAllShinies'] = 'rgb(127, 127, 0)';
+COLORS['route']['current'] = 'rgb(139, 69, 19)';
+COLORS['route']['currentCaughtAll'] = 'rgb(0, 244, 0)';
+COLORS['route']['currentCaughtAllShinies'] = 'rgb(223, 223, 0)';
 
 export const POKEDEXFLAGS: Record<string, number> = {};
 POKEDEXFLAGS['unseen'] = 0;

--- a/src/modules/display.js
+++ b/src/modules/display.js
@@ -132,9 +132,10 @@ export default (player, combatLoop, userInteractions) => {
                     let routeColor; let
                         routeWeight;
                     if (unlocked) {
-                        routeColor = (routeId === player.settings.currentRouteId) ? COLORS.route.current : COLORS.route.unlocked;
-                        routeWeight = (routeId === player.settings.currentRouteId) ? 'bold' : 'normal';
-                        if (routeColor !== COLORS.route.current && route.pokes) { // don't overwrite this color, might confuse the user
+                        let isCurrentRoute = (routeId === player.settings.currentRouteId);
+                        routeColor = isCurrentRoute ? COLORS.route.current : COLORS.route.unlocked;
+                        routeWeight = isCurrentRoute ? 'bold' : 'normal';
+                        if (route.pokes) {
                             let status = 2; // 2 for shiny caught, 1 for regular caught, 0 for missing
                             let encounters = route.pokes || [];
                             if (route._special) {
@@ -153,9 +154,9 @@ export default (player, combatLoop, userInteractions) => {
                                 }
                             }
                             if (status === 2) {
-                                routeColor = COLORS.route.caughtAllShinies;
+                                routeColor = isCurrentRoute ? COLORS.route.currentCaughtAllShinies : COLORS.route.caughtAllShinies;
                             } else if (status === 1) {
-                                routeColor = COLORS.route.caughtAll;
+                                routeColor = isCurrentRoute ? COLORS.route.currentCaughtAll : COLORS.route.caughtAll;
                             }
                         }
                     } else {

--- a/src/modules/display.js
+++ b/src/modules/display.js
@@ -132,7 +132,7 @@ export default (player, combatLoop, userInteractions) => {
                     let routeColor; let
                         routeWeight;
                     if (unlocked) {
-                        let isCurrentRoute = (routeId === player.settings.currentRouteId);
+                        const isCurrentRoute = (routeId === player.settings.currentRouteId);
                         routeColor = isCurrentRoute ? COLORS.route.current : COLORS.route.unlocked;
                         routeWeight = isCurrentRoute ? 'bold' : 'normal';
                         if (route.pokes) {

--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -169,7 +169,7 @@ Poke.prototype.giveExp = function (amount) {
     this.exp += amount;
 };
 Poke.prototype.currentExp = function () { return this.exp; };
-Poke.prototype.nextLevelExp = function () { return this.expTable[this.currentLevel()]; };
+Poke.prototype.nextLevelExp = function () { return this.expTable[this.currentLevel()] || this.currentExp(); };
 Poke.prototype.thisLevelExp = function () { return this.expTable[this.currentLevel() - 1] || 10; };
 Poke.prototype.level = function () { return this.currentLevel(); };
 Poke.prototype.prestigeLevel = function () { return this.prestigeLevel; };

--- a/src/modules/poke.js
+++ b/src/modules/poke.js
@@ -169,7 +169,7 @@ Poke.prototype.giveExp = function (amount) {
     this.exp += amount;
 };
 Poke.prototype.currentExp = function () { return this.exp; };
-Poke.prototype.nextLevelExp = function () { return this.expTable[this.currentLevel()] || this.currentExp(); };
+Poke.prototype.nextLevelExp = function () { return this.expTable[this.currentLevel()] || (this.currentExp() + 1); };
 Poke.prototype.thisLevelExp = function () { return this.expTable[this.currentLevel() - 1] || 10; };
 Poke.prototype.level = function () { return this.currentLevel(); };
 Poke.prototype.prestigeLevel = function () { return this.prestigeLevel; };


### PR DESCRIPTION
This PR adds alternative colors for the current route based on catch status. It should also fix the bug preventing the route list from rendering when a level 100 Pokémon is selected.